### PR TITLE
Generalize the reference to Python installation

### DIFF
--- a/python/client.py
+++ b/python/client.py
@@ -1,4 +1,4 @@
-#!/opt/local/bin/python
+#!/usr/bin/env python
 
 from pmix import *
 

--- a/python/sched.py
+++ b/python/sched.py
@@ -1,4 +1,4 @@
-#!/opt/local/bin/python
+#!/usr/bin/env python
 
 from pmix import *
 import signal, time

--- a/python/server.py
+++ b/python/server.py
@@ -1,4 +1,4 @@
-#!/opt/local/bin/python
+#!/usr/bin/env python
 
 from pmix import *
 import signal, time


### PR DESCRIPTION
Use the more general "/usr/bin/env python" clause

Signed-off-by: Ralph Castain <rhc@pmix.org>