### PR TITLE
update value type in python tests

### DIFF
--- a/python/client.py
+++ b/python/client.py
@@ -14,7 +14,7 @@ def main():
         exit(1)
     # try putting something
     print("PUT")
-    rc = foo.put(PMIX_GLOBAL, "mykey", (1, PMIX_INT32))
+    rc = foo.put(PMIX_GLOBAL, "mykey", {'value':1, 'val_type':PMIX_INT32})
     print("Put result ", rc);
     # commit it
     print("COMMIT")


### PR DESCRIPTION
The python put function is now passed
a value type as a dict instead of a
tuple.

Signed-off-by: Danielle Sikich (Intel) <danielle.sikich@intel.com>