### PR TITLE
Modify the unit tests to be independent

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 # http://www.gnu.org/software/automake
 
 Makefile.in
+.DS_Store
 /ar-lib
 /mdate-sh
 /py-compile

--- a/unit/Makefile
+++ b/unit/Makefile
@@ -13,20 +13,81 @@ sources = cli_stages.c test_cd.c test_common.c test_error.c \
 		test_fence.c test_internal.c test_publish.c test_replace.c test_resolve_peers.c \
 		test_spawn.c utils.c argv.c pmix_object.c unit_list.c unit_progress_threads.c
 
+ifndef PMIXHOME
+ifneq ("$(wildcard /usr/include/pmix.h)","")
+	export PMIXHOME=/usr
+endif
+endif
+
+ifndef PMIXHOME
+ifneq ("$(wildcard /usr/local/include/pmix.h)","")
+	export PMIXHOME=/usr/local
+endif
+endif
+
+ifndef PMIXHOME
+ifneq ("$(wildcard /opt/include/pmix.h)","")
+	export PMIXHOME=/opt
+endif
+endif
+
+ifndef PMIXHOME
+ifneq ("$(wildcard /opt/local/include/pmix.h)","")
+	export PMIXHOME=/opt/local
+endif
+endif
+
+ifdef PMIXHOME
+	export PMIXFIND=-I$(PMIXHOME)/include -L$(PMIXHOME)/lib
+else
+	export PMIXFIND=
+endif
+
+ifndef EVENTHOME
+ifneq ("$(wildcard /usr/include/event.h)","")
+	export EVENTHOME=/usr
+endif
+endif
+
+ifndef EVENTHOME
+ifneq ("$(wildcard /usr/local/include/event.h)","")
+	export EVENTHOME=/usr/local
+endif
+endif
+
+ifndef EVENTHOME
+ifneq ("$(wildcard /opt/include/event.h)","")
+	export EVENTHOME=/opt
+endif
+endif
+
+ifndef EVENTHOME
+ifneq ("$(wildcard /opt/local/include/event.h)","")
+	export EVENTHOME=/opt/local
+endif
+endif
+
+ifdef EVENTHOME
+	export EVENTFIND=-I$(EVENTHOME)/include -L$(EVENTHOME)/lib
+else
+	export EVENTFIND=
+endif
+
+
 pmix_test: pmix_test.c $(sources) test_server.c server_callbacks.c
-	$(CC) -I./ -I$(PMIXHOME)/include -L$(PMIXHOME)/lib -I$(EVENTHOME)/include -L$(EVENTHOME)/lib -o pmix_test pmix_test.c $(sources) test_server.c server_callbacks.c -lpmix -levent
+	$(CC) -I./ $(PMIXFIND) $(EVENTFIND) -o pmix_test pmix_test.c $(sources) test_server.c server_callbacks.c -lpmix -levent
 
 pmix_client: pmix_client.c $(sources)
-	$(CC) -I./ -I$(PMIXHOME)/include -L$(PMIXHOME)/lib -I$(EVENTHOME)/include -L$(EVENTHOME)/lib -o pmix_client pmix_client.c $(sources) -lpmix -levent
+	$(CC) -I./ $(PMIXFIND) $(EVENTFIND) -o pmix_client pmix_client.c $(sources) -lpmix -levent
 
 pmix_regex: pmix_regex.c $(sources) test_server.c server_callbacks.c
-	$(CC) -I./ -I$(PMIXHOME)/include -L$(PMIXHOME)/lib -I$(EVENTHOME)/include -L$(EVENTHOME)/lib -o pmix_regex pmix_regex.c $(sources) test_server.c server_callbacks.c -lpmix -levent
+	$(CC) -I./ $(PMIXFIND) $(EVENTFIND) -o pmix_regex pmix_regex.c $(sources) test_server.c server_callbacks.c -lpmix -levent
 
 pmi_client: pmi_client.c $(sources)
-	$(CC) -I./ -I$(PMIXHOME)/include -L$(PMIXHOME)/lib -I$(EVENTHOME)/include -L$(EVENTHOME)/lib -o pmi_client pmi_client.c $(sources) -lpmi -levent
+	$(CC) -I./ $(PMIXFIND) $(EVENTFIND) -o pmi_client pmi_client.c $(sources) -lpmi -levent
 
 pmi2_client: pmi2_client.c $(sources)
-	$(CC) -I./ -I$(PMIXHOME)/include -L$(PMIXHOME)/lib -I$(EVENTHOME)/include -L$(EVENTHOME)/lib -o pmi2_client pmi2_client.c $(sources) -lpmi2 -levent
+	$(CC) -I./ $(PMIXFIND) $(EVENTFIND) -o pmi2_client pmi2_client.c $(sources) -lpmi2 -levent
 
 -include $(SRC:%.c=%.d)
 

--- a/unit/Makefile
+++ b/unit/Makefile
@@ -6,26 +6,27 @@ all: $(PROGS)
 
 headers = test_common.h cli_stages.h server_callbacks.h utils.h test_fence.h \
         test_publish.h test_spawn.h test_cd.h test_resolve_peers.h test_error.h \
-        test_replace.h test_internal.h test_server.h
+        test_replace.h test_internal.h test_server.h argv.h pmix_object.h unit_list.h \
+        unit_progress_threads.h
 
 sources = cli_stages.c test_cd.c test_common.c test_error.c \
 		test_fence.c test_internal.c test_publish.c test_replace.c test_resolve_peers.c \
-		test_spawn.c utils.c
+		test_spawn.c utils.c argv.c pmix_object.c unit_list.c unit_progress_threads.c
 
-pmix_test: pmix_test.c $(sources)
-	$(CC) -o pmix_test pmix_test.c $(sources) test_server.c server_callbacks.c
+pmix_test: pmix_test.c $(sources) test_server.c server_callbacks.c
+	$(CC) -I./ -I$(PMIXHOME)/include -L$(PMIXHOME)/lib -I$(EVENTHOME)/include -L$(EVENTHOME)/lib -o pmix_test pmix_test.c $(sources) test_server.c server_callbacks.c -lpmix -levent
 
 pmix_client: pmix_client.c $(sources)
-	$(CC) -o pmix_client pmix_client.c $(sources)
+	$(CC) -I./ -I$(PMIXHOME)/include -L$(PMIXHOME)/lib -I$(EVENTHOME)/include -L$(EVENTHOME)/lib -o pmix_client pmix_client.c $(sources) -lpmix -levent
 
-pmix_regex: pmix_regex.c $(sources)
-	$(CC) -o pmix_regex pmix_regex.c $(sources) test_server.c server_callbacks.c
+pmix_regex: pmix_regex.c $(sources) test_server.c server_callbacks.c
+	$(CC) -I./ -I$(PMIXHOME)/include -L$(PMIXHOME)/lib -I$(EVENTHOME)/include -L$(EVENTHOME)/lib -o pmix_regex pmix_regex.c $(sources) test_server.c server_callbacks.c -lpmix -levent
 
 pmi_client: pmi_client.c $(sources)
-	$(CC) -o pmi_client pmi_client.c $(sources) -lpmi
+	$(CC) -I./ -I$(PMIXHOME)/include -L$(PMIXHOME)/lib -I$(EVENTHOME)/include -L$(EVENTHOME)/lib -o pmi_client pmi_client.c $(sources) -lpmi -levent
 
 pmi2_client: pmi2_client.c $(sources)
-	$(CC) -o pmi2_client pmi2_client.c $(sources) -lpmi2
+	$(CC) -I./ -I$(PMIXHOME)/include -L$(PMIXHOME)/lib -I$(EVENTHOME)/include -L$(EVENTHOME)/lib -o pmi2_client pmi2_client.c $(sources) -lpmi2 -levent
 
 -include $(SRC:%.c=%.d)
 

--- a/unit/README
+++ b/unit/README
@@ -1,0 +1,24 @@
+These are unit tests for PMIx. They are designed to be built
+using a C compiler (specified by setting CC in the environment)
+and require the following:
+
+* you have set PMIXHOME in the environment to point to the
+  prefix location where PMIx was installed
+
+* you have set EVENTHOME in the environment to point to the
+  prefix location where libevent was installed
+
+If either PMIx or libevent (or both) were installed in default
+locations, then you don't need to provide these envars. The
+Makefile will search for the installation in the following
+locations (in precedence order):
+
+* /usr
+* /usr/local
+* /opt
+* /opt/local
+
+If it doesn't find an installation in any of those locations,
+the compile is likely to fail. Your only option at that point
+is to help the Makefile out by setting the appropriate envar
+as above.

--- a/unit/argv.c
+++ b/unit/argv.c
@@ -1,0 +1,606 @@
+/*
+ * Copyright (c) 2004-2005 The Trustees of Indiana University and Indiana
+ *                         University Research and Technology
+ *                         Corporation.  All rights reserved.
+ * Copyright (c) 2004-2005 The University of Tennessee and The University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
+ * Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
+ *                         University of Stuttgart.  All rights reserved.
+ * Copyright (c) 2004-2005 The Regents of the University of California.
+ *                         All rights reserved.
+ * Copyright (c) 2007      Voltaire. All rights reserved.
+ * Copyright (c) 2012      Los Alamos National Security, LLC. All rights reserved.
+ * Copyright (c) 2014-2019 Intel, Inc.  All rights reserved.
+ *
+ * Copyright (c) 2015      Research Organization for Information Science
+ *                         and Technology (RIST). All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+
+
+#include <stdlib.h>
+#include <string.h>
+
+#include "argv.h"
+
+#define ARGSIZE 128
+
+
+/*
+ * Append a string to the end of a new or existing argv array.
+ */
+pmix_status_t pmix_argv_append(int *argc, char ***argv, const char *arg)
+{
+    pmix_status_t rc;
+
+    /* add the new element */
+    if (PMIX_SUCCESS != (rc = pmix_argv_append_nosize(argv, arg))) {
+        return rc;
+    }
+
+    *argc = pmix_argv_count(*argv);
+
+    return PMIX_SUCCESS;
+}
+
+pmix_status_t pmix_argv_append_nosize(char ***argv, const char *arg)
+{
+    int argc;
+
+  /* Create new argv. */
+
+  if (NULL == *argv) {
+    *argv = (char**) malloc(2 * sizeof(char *));
+    if (NULL == *argv) {
+        return PMIX_ERR_OUT_OF_RESOURCE;
+    }
+    argc = 0;
+    (*argv)[0] = NULL;
+    (*argv)[1] = NULL;
+  }
+
+  /* Extend existing argv. */
+  else {
+        /* count how many entries currently exist */
+        argc = pmix_argv_count(*argv);
+
+        *argv = (char**) realloc(*argv, (argc + 2) * sizeof(char *));
+        if (NULL == *argv) {
+            return PMIX_ERR_OUT_OF_RESOURCE;
+        }
+    }
+
+    /* Set the newest element to point to a copy of the arg string */
+
+    (*argv)[argc] = strdup(arg);
+    if (NULL == (*argv)[argc]) {
+        return PMIX_ERR_OUT_OF_RESOURCE;
+    }
+
+    argc = argc + 1;
+    (*argv)[argc] = NULL;
+
+    return PMIX_SUCCESS;
+}
+
+pmix_status_t pmix_argv_prepend_nosize(char ***argv, const char *arg)
+{
+    int argc;
+    int i;
+
+    /* Create new argv. */
+
+    if (NULL == *argv) {
+        *argv = (char**) malloc(2 * sizeof(char *));
+        if (NULL == *argv) {
+            return PMIX_ERR_OUT_OF_RESOURCE;
+        }
+        (*argv)[0] = strdup(arg);
+        (*argv)[1] = NULL;
+    } else {
+        /* count how many entries currently exist */
+        argc = pmix_argv_count(*argv);
+
+        *argv = (char**) realloc(*argv, (argc + 2) * sizeof(char *));
+        if (NULL == *argv) {
+            return PMIX_ERR_OUT_OF_RESOURCE;
+        }
+        (*argv)[argc+1] = NULL;
+
+        /* shift all existing elements down 1 */
+        for (i=argc; 0 < i; i--) {
+            (*argv)[i] = (*argv)[i-1];
+        }
+        (*argv)[0] = strdup(arg);
+    }
+
+    return PMIX_SUCCESS;
+}
+
+pmix_status_t pmix_argv_append_unique_idx(int *idx, char ***argv, const char *arg)
+{
+    int i;
+    pmix_status_t rc;
+
+    /* if the provided array is NULL, then the arg cannot be present,
+     * so just go ahead and append
+     */
+    if (NULL == *argv) {
+        goto add;
+    }
+    /* see if this arg is already present in the array */
+    for (i=0; NULL != (*argv)[i]; i++) {
+        if (0 == strcmp(arg, (*argv)[i])) {
+            /* already exists */
+            *idx = i;
+            return PMIX_SUCCESS;
+        }
+    }
+add:
+    if (PMIX_SUCCESS != (rc = pmix_argv_append_nosize(argv, arg))) {
+        return rc;
+    }
+    *idx = pmix_argv_count(*argv)-1;
+
+    return PMIX_SUCCESS;
+}
+
+pmix_status_t pmix_argv_append_unique_nosize(char ***argv, const char *arg)
+{
+    int i;
+
+    /* if the provided array is NULL, then the arg cannot be present,
+     * so just go ahead and append
+     */
+    if (NULL == *argv) {
+        return pmix_argv_append_nosize(argv, arg);
+    }
+
+    /* see if this arg is already present in the array */
+    for (i=0; NULL != (*argv)[i]; i++) {
+        if (0 == strcmp(arg, (*argv)[i])) {
+            /* already exists */
+            return PMIX_SUCCESS;
+        }
+    }
+
+    /* we get here if the arg is not in the array - so add it */
+    return pmix_argv_append_nosize(argv, arg);
+}
+
+/*
+ * Free a NULL-terminated argv array.
+ */
+void pmix_argv_free(char **argv)
+{
+  char **p;
+
+  if (NULL == argv)
+    return;
+
+  for (p = argv; NULL != *p; ++p) {
+    free(*p);
+  }
+
+  free(argv);
+}
+
+
+/*
+ * Split a string into a NULL-terminated argv array.
+ */
+static char **pmix_argv_split_inter(const char *src_string, int delimiter,
+        int include_empty)
+{
+  char arg[ARGSIZE];
+  char **argv = NULL;
+  const char *p;
+  char *argtemp;
+  int argc = 0;
+  size_t arglen;
+
+  while (src_string && *src_string) {
+    p = src_string;
+    arglen = 0;
+
+    while (('\0' != *p) && (*p != delimiter)) {
+      ++p;
+      ++arglen;
+    }
+
+    /* zero length argument, skip */
+
+    if (src_string == p) {
+      if (include_empty) {
+        arg[0] = '\0';
+        if (PMIX_SUCCESS != pmix_argv_append(&argc, &argv, arg))
+          return NULL;
+      }
+    }
+
+    /* tail argument, add straight from the original string */
+
+    else if ('\0' == *p) {
+      if (PMIX_SUCCESS != pmix_argv_append(&argc, &argv, src_string))
+        return NULL;
+      src_string = p;
+      continue;
+    }
+
+    /* long argument, malloc buffer, copy and add */
+
+    else if (arglen > (ARGSIZE - 1)) {
+        argtemp = (char*) malloc(arglen + 1);
+      if (NULL == argtemp)
+        return NULL;
+
+      pmix_strncpy(argtemp, src_string, arglen);
+      argtemp[arglen] = '\0';
+
+      if (PMIX_SUCCESS != pmix_argv_append(&argc, &argv, argtemp)) {
+        free(argtemp);
+        return NULL;
+      }
+
+      free(argtemp);
+    }
+
+    /* short argument, copy to buffer and add */
+
+    else {
+      pmix_strncpy(arg, src_string, arglen);
+      arg[arglen] = '\0';
+
+      if (PMIX_SUCCESS != pmix_argv_append(&argc, &argv, arg))
+        return NULL;
+    }
+
+    src_string = p + 1;
+  }
+
+  /* All done */
+
+  return argv;
+}
+
+char **pmix_argv_split(const char *src_string, int delimiter)
+{
+    return pmix_argv_split_inter(src_string, delimiter, 0);
+}
+
+char **pmix_argv_split_with_empty(const char *src_string, int delimiter)
+{
+    return pmix_argv_split_inter(src_string, delimiter, 1);
+}
+
+/*
+ * Return the length of a NULL-terminated argv array.
+ */
+int pmix_argv_count(char **argv)
+{
+  char **p;
+  int i;
+
+  if (NULL == argv)
+    return 0;
+
+  for (i = 0, p = argv; *p; i++, p++)
+    continue;
+
+  return i;
+}
+
+
+/*
+ * Join all the elements of an argv array into a single
+ * newly-allocated string.
+ */
+char *pmix_argv_join(char **argv, int delimiter)
+{
+  char **p;
+  char *pp;
+  char *str;
+  size_t str_len = 0;
+  size_t i;
+
+  /* Bozo case */
+
+  if (NULL == argv || NULL == argv[0]) {
+      return strdup("");
+  }
+
+  /* Find the total string length in argv including delimiters.  The
+     last delimiter is replaced by the NULL character. */
+
+  for (p = argv; *p; ++p) {
+    str_len += strlen(*p) + 1;
+  }
+
+  /* Allocate the string. */
+
+  if (NULL == (str = (char*) malloc(str_len)))
+    return NULL;
+
+  /* Loop filling in the string. */
+
+  str[--str_len] = '\0';
+  p = argv;
+  pp = *p;
+
+  for (i = 0; i < str_len; ++i) {
+    if ('\0' == *pp) {
+
+      /* End of a string, fill in a delimiter and go to the next
+         string. */
+
+      str[i] = (char) delimiter;
+      ++p;
+      pp = *p;
+    } else {
+      str[i] = *pp++;
+    }
+  }
+
+  /* All done */
+
+  return str;
+}
+
+
+/*
+ * Join all the elements of an argv array from within a
+ * specified range into a single newly-allocated string.
+ */
+char *pmix_argv_join_range(char **argv, size_t start, size_t end, int delimiter)
+{
+    char **p;
+    char *pp;
+    char *str;
+    size_t str_len = 0;
+    size_t i;
+
+    /* Bozo case */
+
+    if (NULL == argv || NULL == argv[0] || (int)start > pmix_argv_count(argv)) {
+        return strdup("");
+    }
+
+    /* Find the total string length in argv including delimiters.  The
+     last delimiter is replaced by the NULL character. */
+
+    for (p = &argv[start], i=start; *p && i < end; ++p, ++i) {
+        str_len += strlen(*p) + 1;
+    }
+
+    /* Allocate the string. */
+
+    if (NULL == (str = (char*) malloc(str_len)))
+        return NULL;
+
+    /* Loop filling in the string. */
+
+    str[--str_len] = '\0';
+    p = &argv[start];
+    pp = *p;
+
+    for (i = 0; i < str_len; ++i) {
+        if ('\0' == *pp) {
+
+            /* End of a string, fill in a delimiter and go to the next
+             string. */
+
+            str[i] = (char) delimiter;
+            ++p;
+            pp = *p;
+        } else {
+            str[i] = *pp++;
+        }
+    }
+
+    /* All done */
+
+    return str;
+}
+
+
+/*
+ * Return the number of bytes consumed by an argv array.
+ */
+size_t pmix_argv_len(char **argv)
+{
+  char **p;
+  size_t length;
+
+  if (NULL == argv)
+    return (size_t) 0;
+
+  length = sizeof(char *);
+
+  for (p = argv; *p; ++p) {
+    length += strlen(*p) + 1 + sizeof(char *);
+  }
+
+  return length;
+}
+
+
+/*
+ * Copy a NULL-terminated argv array.
+ */
+char **pmix_argv_copy(char **argv)
+{
+  char **dupv = NULL;
+  int dupc = 0;
+
+  if (NULL == argv)
+    return NULL;
+
+  /* create an "empty" list, so that we return something valid if we
+     were passed a valid list with no contained elements */
+  dupv = (char**) malloc(sizeof(char*));
+  dupv[0] = NULL;
+
+  while (NULL != *argv) {
+    if (PMIX_SUCCESS != pmix_argv_append(&dupc, &dupv, *argv)) {
+      pmix_argv_free(dupv);
+      return NULL;
+    }
+
+    ++argv;
+  }
+
+  /* All done */
+
+  return dupv;
+}
+
+
+pmix_status_t pmix_argv_delete(int *argc, char ***argv, int start, int num_to_delete)
+{
+    int i;
+    int count;
+    int suffix_count;
+    char **tmp;
+
+    /* Check for the bozo cases */
+    if (NULL == argv || NULL == *argv || 0 == num_to_delete) {
+        return PMIX_SUCCESS;
+    }
+    count = pmix_argv_count(*argv);
+    if (start > count) {
+        return PMIX_SUCCESS;
+    } else if (start < 0 || num_to_delete < 0) {
+        return PMIX_ERR_BAD_PARAM;
+    }
+
+    /* Ok, we have some tokens to delete.  Calculate the new length of
+       the argv array. */
+
+    suffix_count = count - (start + num_to_delete);
+    if (suffix_count < 0) {
+        suffix_count = 0;
+    }
+
+    /* Free all items that are being deleted */
+
+    for (i = start; i < count && i < start + num_to_delete; ++i) {
+        free((*argv)[i]);
+    }
+
+    /* Copy the suffix over the deleted items */
+
+    for (i = start; i < start + suffix_count; ++i) {
+        (*argv)[i] = (*argv)[i + num_to_delete];
+    }
+
+    /* Add the trailing NULL */
+
+    (*argv)[i] = NULL;
+
+    /* adjust the argv array */
+    tmp = (char**)realloc(*argv, sizeof(char*) * (i + 1));
+    if (NULL != tmp) *argv = tmp;
+
+    /* adjust the argc */
+    (*argc) -= num_to_delete;
+
+    return PMIX_SUCCESS;
+}
+
+
+pmix_status_t pmix_argv_insert(char ***target, int start, char **source)
+{
+    int i, source_count, target_count;
+    int suffix_count;
+
+    /* Check for the bozo cases */
+
+    if (NULL == target || NULL == *target || start < 0) {
+        return PMIX_ERR_BAD_PARAM;
+    } else if (NULL == source) {
+        return PMIX_SUCCESS;
+    }
+
+    /* Easy case: appending to the end */
+
+    target_count = pmix_argv_count(*target);
+    source_count = pmix_argv_count(source);
+    if (start > target_count) {
+        for (i = 0; i < source_count; ++i) {
+            pmix_argv_append(&target_count, target, source[i]);
+        }
+    }
+
+    /* Harder: insertting into the middle */
+
+    else {
+
+        /* Alloc out new space */
+
+        *target = (char**) realloc(*target,
+                                   sizeof(char *) * (target_count + source_count + 1));
+
+        /* Move suffix items down to the end */
+
+        suffix_count = target_count - start;
+        for (i = suffix_count - 1; i >= 0; --i) {
+            (*target)[start + source_count + i] =
+                (*target)[start + i];
+        }
+        (*target)[start + suffix_count + source_count] = NULL;
+
+        /* Strdup in the source argv */
+
+        for (i = start; i < start + source_count; ++i) {
+            (*target)[i] = strdup(source[i - start]);
+        }
+    }
+
+    /* All done */
+
+    return PMIX_SUCCESS;
+}
+
+pmix_status_t pmix_argv_insert_element(char ***target, int location, char *source)
+{
+    int i, target_count;
+    int suffix_count;
+
+    /* Check for the bozo cases */
+
+    if (NULL == target || NULL == *target || location < 0) {
+        return PMIX_ERR_BAD_PARAM;
+    } else if (NULL == source) {
+        return PMIX_SUCCESS;
+    }
+
+    /* Easy case: appending to the end */
+    target_count = pmix_argv_count(*target);
+    if (location > target_count) {
+        pmix_argv_append(&target_count, target, source);
+        return PMIX_SUCCESS;
+    }
+
+    /* Alloc out new space */
+    *target = (char**) realloc(*target,
+                               sizeof(char*) * (target_count + 2));
+
+    /* Move suffix items down to the end */
+    suffix_count = target_count - location;
+    for (i = suffix_count - 1; i >= 0; --i) {
+        (*target)[location + 1 + i] =
+        (*target)[location + i];
+    }
+    (*target)[location + suffix_count + 1] = NULL;
+
+    /* Strdup in the source */
+    (*target)[location] = strdup(source);
+
+    /* All done */
+    return PMIX_SUCCESS;
+}

--- a/unit/argv.h
+++ b/unit/argv.h
@@ -1,0 +1,312 @@
+/*
+ * Copyright (c) 2004-2007 The Trustees of Indiana University and Indiana
+ *                         University Research and Technology
+ *                         Corporation.  All rights reserved.
+ * Copyright (c) 2004-2005 The University of Tennessee and The University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
+ * Copyright (c) 2004-2008 High Performance Computing Center Stuttgart,
+ *                         University of Stuttgart.  All rights reserved.
+ * Copyright (c) 2004-2005 The Regents of the University of California.
+ *                         All rights reserved.
+ * Copyright (c) 2007      Los Alamos National Security, LLC.
+ *                         All rights reserved.
+ * Copyright (c) 2007      Voltaire. All rights reserved.
+ * Copyright (c) 2012      Los Alamos National Security, LLC. All rights reserved.
+ * Copyright (c) 2015-2019 Intel, Inc.  All rights reserved.
+ *
+ * Copyright (c) 2015-2019 Research Organization for Information Science
+ *                         and Technology (RIST).  All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+
+/**
+ * @file
+ *
+ * Generic routines for "argv"-like handling.  Helpful for creating
+ * arrays of strings, especially when creating command lines.
+ */
+
+#ifndef PMIX_ARGV_H
+#define PMIX_ARGV_H
+
+
+#include <sys/types.h>
+#include <pmix_common.h>
+
+  /**
+   * Append a string (by value) to an new or existing NULL-terminated
+   * argv array.
+   *
+   * @param argc Pointer to the length of the argv array.  Must not be
+   * NULL.
+   * @param argv Pointer to an argv array.
+   * @param str Pointer to the string to append.
+   *
+   * @retval PMIX_SUCCESS On success
+   * @retval PMIX_ERROR On failure
+   *
+   * This function adds a string to an argv array of strings by value;
+   * it is permissable to pass a string on the stack as the str
+   * argument to this function.
+   *
+   * To add the first entry to an argv array, call this function with
+   * (*argv == NULL).  This function will allocate an array of length
+   * 2; the first entry will point to a copy of the string passed in
+   * arg, the second entry will be set to NULL.
+   *
+   * If (*argv != NULL), it will be realloc'ed to be 1 (char*) larger,
+   * and the next-to-last entry will point to a copy of the string
+   * passed in arg.  The last entry will be set to NULL.
+   *
+   * Just to reinforce what was stated above: the string is copied by
+   * value into the argv array; there is no need to keep the original
+   * string (i.e., the arg parameter) after invoking this function.
+   */
+pmix_status_t pmix_argv_append(int *argc, char ***argv, const char *arg);
+
+  /**
+   * Append to an argv-style array, but ignore the size of the array.
+   *
+   * @param argv Pointer to an argv array.
+   * @param str Pointer to the string to append.
+   *
+   * @retval PMIX_SUCCESS On success
+   * @retval PMIX_ERROR On failure
+   *
+   * This function is identical to the pmix_argv_append() function
+   * except that it does not take a pointer to an argc (integer
+   * representing the size of the array).  This is handy for
+   * argv-style arrays that do not have integers that are actively
+   * maintaing their sizes.
+   */
+pmix_status_t pmix_argv_append_nosize(char ***argv, const char *arg);
+
+/**
+ * Insert the provided arg at the beginning of the array
+ *
+ * @param argv Pointer to an argv array
+ * @param str Pointer to the string to prepend
+ *
+ * @retval PMIX_SUCCESS On success
+ * @retval PMIX_ERROR On failure
+ */
+pmix_status_t pmix_argv_prepend_nosize(char ***argv, const char *arg);
+
+/**
+ * Append to an argv-style array, but only if the provided argument
+ * doesn't already exist somewhere in the array. Ignore the size of the array.
+ *
+ * @param argv Pointer to an argv array.
+ * @param str Pointer to the string to append.
+ *
+ * @retval PMIX_SUCCESS On success
+ * @retval PMIX_ERROR On failure
+ *
+ * This function is identical to the pmix_argv_append_nosize() function
+ * except that it only appends the provided argument if it does not already
+ * exist in the provided array.
+ */
+pmix_status_t pmix_argv_append_unique_nosize(char ***argv, const char *arg);
+
+/**
+ * Append to an argv-style array, but only if the provided argument
+ * doesn't already exist somewhere in the array. Ignore the size of the array.
+ * Defines the index of the found/added item in the array.
+ *
+ * @param idx Index the found/added item in the array.
+ * @param argv Pointer to an argv array.
+ * @param str Pointer to the string to append.
+ *
+ * @retval PMIX_SUCCESS On success
+ * @retval PMIX_ERROR On failure
+ *
+ * This function is identical to the pmix_argv_append_unique_nosize() function
+ * but it has an extra argument defining the index of the item in the array.
+ */
+pmix_status_t pmix_argv_append_unique_idx(int *idx, char ***argv, const char *arg);
+
+/**
+   * Free a NULL-terminated argv array.
+   *
+   * @param argv Argv array to free.
+   *
+   * This function frees an argv array and all of the strings that it
+   * contains.  Since the argv parameter is passed by value, it is not
+   * set to NULL in the caller's scope upon return.
+   *
+   * It is safe to invoke this function with a NULL pointer.  It is
+   * not safe to invoke this function with a non-NULL-terminated argv
+   * array.
+   */
+void pmix_argv_free(char **argv);
+
+  /**
+   * Split a string into a NULL-terminated argv array. Do not include empty
+   * strings in result array.
+   *
+   * @param src_string Input string.
+   * @param delimiter Delimiter character.
+   *
+   * @retval argv pointer to new argv array on success
+   * @retval NULL on error
+   *
+   * All strings are insertted into the argv array by value; the
+   * newly-allocated array makes no references to the src_string
+   * argument (i.e., it can be freed after calling this function
+   * without invalidating the output argv).
+   */
+char **pmix_argv_split(const char *src_string, int delimiter);
+
+  /**
+   * Split a string into a NULL-terminated argv array. Include empty
+   * strings in result array.
+   *
+   * @param src_string Input string.
+   * @param delimiter Delimiter character.
+   *
+   * @retval argv pointer to new argv array on success
+   * @retval NULL on error
+   *
+   * All strings are insertted into the argv array by value; the
+   * newly-allocated array makes no references to the src_string
+   * argument (i.e., it can be freed after calling this function
+   * without invalidating the output argv).
+   */
+char **pmix_argv_split_with_empty(const char *src_string, int delimiter);
+
+  /**
+   * Return the length of a NULL-terminated argv array.
+   *
+   * @param argv The input argv array.
+   *
+   * @retval 0 If NULL is passed as argv.
+   * @retval count Number of entries in the argv array.
+   *
+   * The argv array must be NULL-terminated.
+   */
+int pmix_argv_count(char **argv);
+
+  /**
+   * Join all the elements of an argv array into a single
+   * newly-allocated string.
+   *
+   * @param argv The input argv array.
+   * @param delimiter Delimiter character placed between each argv string.
+   *
+   * @retval new_string Output string on success.
+   * @retval NULL On failure.
+   *
+   * Similar to the Perl join function, this function takes an input
+   * argv and joins them into into a single string separated by the
+   * delimiter character.
+   *
+   * It is the callers responsibility to free the returned string.
+   */
+char *pmix_argv_join(char **argv, int delimiter);
+
+char *pmix_argv_join_range(char **argv, size_t start, size_t end, int delimiter);
+
+  /**
+   * Return the number of bytes consumed by an argv array.
+   *
+   * @param argv The input argv array.
+   *
+   * Count the number of bytes consumed by a NULL-terminated argv
+   * array.  This includes the number of bytes used by each of the
+   * strings as well as the pointers used in the argv array.
+   */
+size_t pmix_argv_len(char **argv);
+
+  /**
+   * Copy a NULL-terminated argv array.
+   *
+   * @param argv The input argv array.
+   *
+   * @retval argv Copied argv array on success.
+   * @retval NULL On failure.
+   *
+   * Copy an argv array, including copying all off its strings.
+   * Specifically, the output argv will be an array of the same length
+   * as the input argv, and strcmp(argv_in[i], argv_out[i]) will be 0.
+   */
+char **pmix_argv_copy(char **argv);
+
+    /**
+     * Delete one or more tokens from the middle of an argv.
+     *
+     * @param argv The argv to delete from
+     * @param start The index of the first token to delete
+     * @param num_to_delete How many tokens to delete
+     *
+     * @retval PMIX_SUCCESS Always
+     *
+     * Delete some tokens from within an existing argv.  The start
+     * parameter specifies the first token to delete, and will delete
+     * (num_to_delete-1) tokens following it.  argv will be realloc()ed
+     * to *argc - num_deleted size.
+     *
+     * If start is beyond the end of the argv array, this function is
+     * a no-op.
+     *
+     * If num_to_delete runs beyond the end of the argv array, this
+     * function will delete all tokens starting with start to the end
+     * of the array.
+     *
+     * All deleted items in the argv array will have their contents
+     * free()ed (it is assumed that the argv "owns" the memory that
+     * the pointer points to).
+     */
+pmix_status_t pmix_argv_delete(int *argc, char ***argv, int start, int num_to_delete);
+
+    /**
+     * Insert one argv array into the middle of another
+     *
+     * @param target The argv to insert tokens into
+     * @param start Index where the first token will be placed in target
+     * @param source The argv to copy tokens from
+     *
+     * @retval PMIX_SUCCESS upon success
+     * @retval PMIX_BAD_PARAM if any parameters are non-sensical
+     *
+     * This function takes one arg and inserts it in the middle of
+     * another.  The first token in source will be insertted at index
+     * start in the target argv; all other tokens will follow it.
+     * Similar to pmix_argv_append(), the target may be realloc()'ed
+     * to accomodate the new storage requirements.
+     *
+     * The source array is left unaffected -- its contents are copied
+     * by value over to the target array (i.e., the strings that
+     * source points to are strdup'ed into the new locations in
+     * target).
+     */
+pmix_status_t pmix_argv_insert(char ***target, int start, char **source);
+
+/**
+ * Insert one argv element in front of a specific position in an array
+ *
+ * @param target The argv to insert tokens into
+ * @param location Index where the token will be placed in target
+ * @param source The token to be inserted
+ *
+ * @retval PMIX_SUCCESS upon success
+ * @retval PMIX_BAD_PARAM if any parameters are non-sensical
+ *
+ * This function takes one arg and inserts it in the middle of
+ * another.  The token will be inserted at the specified index
+ * in the target argv; all other tokens will be shifted down.
+ * Similar to pmix_argv_append(), the target may be realloc()'ed
+ * to accomodate the new storage requirements.
+ *
+ * The source token is left unaffected -- its contents are copied
+ * by value over to the target array (i.e., the string that
+ * source points to is strdup'ed into the new location in
+ * target).
+ */
+pmix_status_t pmix_argv_insert_element(char ***target, int location, char *source);
+
+#endif /* PMIX_ARGV_H */

--- a/unit/cli_stages.d
+++ b/unit/cli_stages.d
@@ -210,7 +210,7 @@ cli_stages.o: cli_stages.c cli_stages.h \
  /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/sys/_types/_mach_port_t.h \
  /Users/rhc/pmix/build/clean/include/pmix.h \
  /Users/rhc/pmix/build/clean/include/pmix/src/class/pmix_hash_table.h \
- /Users/rhc/pmix/build/clean/include/pmix/src/class/pmix_list.h \
+ /Users/rhc/pmix/build/clean/include/pmix/src/class/unit_list.h \
  /Users/rhc/pmix/build/clean/include/pmix/src/class/pmix_hotel.h \
  /Users/rhc/pmix/build/clean/include/pmix/src/event/pmix_event.h \
  /Users/rhc/pmix/build/clean/include/pmix/src/threads/threads.h \
@@ -660,7 +660,7 @@ cli_stages.h:
 
 /Users/rhc/pmix/build/clean/include/pmix/src/class/pmix_hash_table.h:
 
-/Users/rhc/pmix/build/clean/include/pmix/src/class/pmix_list.h:
+/Users/rhc/pmix/build/clean/include/pmix/src/class/unit_list.h:
 
 /Users/rhc/pmix/build/clean/include/pmix/src/class/pmix_hotel.h:
 

--- a/unit/cli_stages.h
+++ b/unit/cli_stages.h
@@ -25,10 +25,8 @@
 #include <sys/time.h>
 #include <time.h>
 #include <errno.h>
-#include "src/include/pmix_globals.h"
+#include <event.h>
 #include "pmix_server.h"
-#include "src/class/pmix_list.h"
-#include "src/mca/ptl/base/base.h"
 
 #include "test_common.h"
 
@@ -38,7 +36,7 @@ typedef enum {
 } cli_state_t;
 
 typedef struct {
-    pmix_list_t modex;
+    unit_list_t modex;
     pid_t pid;
     int sd;
     pmix_event_t *ev;

--- a/unit/pmix_client.c
+++ b/unit/pmix_client.c
@@ -22,7 +22,6 @@
  * $HEADER$
  *
  */
-#include <src/include/pmix_config.h>
 #include <pmix.h>
 
 #include <stdio.h>
@@ -30,7 +29,6 @@
 #include <unistd.h>
 #include <time.h>
 
-#include "src/class/pmix_object.h"
 #include "test_common.h"
 #include "test_fence.h"
 #include "test_publish.h"

--- a/unit/pmix_client.d
+++ b/unit/pmix_client.d
@@ -202,7 +202,7 @@ pmix_client.o: pmix_client.c \
  /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/sys/qos.h \
  /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/sys/_types/_mach_port_t.h \
  /Users/rhc/pmix/build/clean/include/pmix/src/class/pmix_hash_table.h \
- /Users/rhc/pmix/build/clean/include/pmix/src/class/pmix_list.h \
+ /Users/rhc/pmix/build/clean/include/pmix/src/class/unit_list.h \
  /Users/rhc/pmix/build/clean/include/pmix/src/class/pmix_hotel.h \
  /Users/rhc/pmix/build/clean/include/pmix/src/event/pmix_event.h \
  /Users/rhc/pmix/build/clean/include/pmix/src/threads/threads.h \
@@ -636,7 +636,7 @@ test_common.h:
 
 /Users/rhc/pmix/build/clean/include/pmix/src/class/pmix_hash_table.h:
 
-/Users/rhc/pmix/build/clean/include/pmix/src/class/pmix_list.h:
+/Users/rhc/pmix/build/clean/include/pmix/src/class/unit_list.h:
 
 /Users/rhc/pmix/build/clean/include/pmix/src/class/pmix_hotel.h:
 

--- a/unit/pmix_object.c
+++ b/unit/pmix_object.c
@@ -1,0 +1,223 @@
+/*
+ * Copyright (c) 2004-2005 The Trustees of Indiana University and Indiana
+ *                         University Research and Technology
+ *                         Corporation.  All rights reserved.
+ * Copyright (c) 2004-2005 The University of Tennessee and The University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
+ * Copyright (c) 2004-2007 High Performance Computing Center Stuttgart,
+ *                         University of Stuttgart.  All rights reserved.
+ * Copyright (c) 2004-2005 The Regents of the University of California.
+ *                         All rights reserved.
+ * Copyright (c) 2014-2019 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2016      Research Organization for Information Science
+ *                         and Technology (RIST). All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+
+/**
+ * @file
+ *
+ * Implementation of pmix_object_t, the base pmix foundation class
+ */
+
+
+#include <stdio.h>
+#include <pthread.h>
+
+#include "pmix_object.h"
+
+/*
+ * Instantiation of class descriptor for the base class.  This is
+ * special, since be mark it as already initialized, with no parent
+ * and no constructor or destructor.
+ */
+pmix_class_t pmix_object_t_class = {
+    "pmix_object_t",      /* name */
+    NULL,                 /* parent class */
+    NULL,                 /* constructor */
+    NULL,                 /* destructor */
+    1,                    /* initialized  -- this class is preinitialized */
+    0,                    /* class hierarchy depth */
+    NULL,                 /* array of constructors */
+    NULL,                 /* array of destructors */
+    sizeof(pmix_object_t) /* size of the pmix object */
+};
+
+int pmix_class_init_epoch = 1;
+
+/*
+ * Local variables
+ */
+static pthread_mutex_t class_mutex = PTHREAD_MUTEX_INITIALIZER;
+static void** classes = NULL;
+static int num_classes = 0;
+static int max_classes = 0;
+static const int increment = 10;
+
+
+/*
+ * Local functions
+ */
+static void save_class(pmix_class_t *cls);
+static void expand_array(void);
+
+
+/*
+ * Lazy initialization of class descriptor.
+ */
+void pmix_class_initialize(pmix_class_t *cls)
+{
+    pmix_class_t *c;
+    pmix_construct_t* cls_construct_array;
+    pmix_destruct_t* cls_destruct_array;
+    int cls_construct_array_count;
+    int cls_destruct_array_count;
+    int i;
+
+    assert(cls);
+
+    /* Check to see if anyone initialized
+       this class before we got a chance to */
+
+    if (pmix_class_init_epoch == cls->cls_initialized) {
+        return;
+    }
+    pthread_mutex_lock(&class_mutex);
+
+    /* If another thread initializing this same class came in at
+       roughly the same time, it may have gotten the lock and
+       initialized.  So check again. */
+
+    if (pmix_class_init_epoch == cls->cls_initialized) {
+        pthread_mutex_unlock(&class_mutex);
+        return;
+    }
+
+    /*
+     * First calculate depth of class hierarchy
+     * And the number of constructors and destructors
+     */
+
+    cls->cls_depth = 0;
+    cls_construct_array_count = 0;
+    cls_destruct_array_count  = 0;
+    for (c = cls; c; c = c->cls_parent) {
+        if( NULL != c->cls_construct ) {
+            cls_construct_array_count++;
+        }
+        if( NULL != c->cls_destruct ) {
+            cls_destruct_array_count++;
+        }
+        cls->cls_depth++;
+    }
+
+    /*
+     * Allocate arrays for hierarchy of constructors and destructors
+     * plus for each a NULL-sentinel
+     */
+
+    cls->cls_construct_array =
+        (void (**)(pmix_object_t*))malloc((cls_construct_array_count +
+                                           cls_destruct_array_count + 2) *
+                                          sizeof(pmix_construct_t) );
+    if (NULL == cls->cls_construct_array) {
+        perror("Out of memory");
+        exit(-1);
+    }
+    cls->cls_destruct_array =
+        cls->cls_construct_array + cls_construct_array_count + 1;
+
+    /*
+     * The constructor array is reversed, so start at the end
+     */
+
+    cls_construct_array = cls->cls_construct_array + cls_construct_array_count;
+    cls_destruct_array  = cls->cls_destruct_array;
+
+    c = cls;
+    *cls_construct_array = NULL;  /* end marker for the constructors */
+    for (i = 0; i < cls->cls_depth; i++) {
+        if( NULL != c->cls_construct ) {
+            --cls_construct_array;
+            *cls_construct_array = c->cls_construct;
+        }
+        if( NULL != c->cls_destruct ) {
+            *cls_destruct_array = c->cls_destruct;
+            cls_destruct_array++;
+        }
+        c = c->cls_parent;
+    }
+    *cls_destruct_array = NULL;  /* end marker for the destructors */
+
+    cls->cls_initialized = pmix_class_init_epoch;
+    save_class(cls);
+
+    /* All done */
+
+    pthread_mutex_unlock(&class_mutex);
+}
+
+
+/*
+ * Note that this is finalize for *all* classes.
+ */
+int pmix_class_finalize(void)
+{
+    int i;
+
+    if (2147483647 == pmix_class_init_epoch) {
+        pmix_class_init_epoch = 1;
+    } else {
+        pmix_class_init_epoch++;
+    }
+
+    if (NULL != classes) {
+        for (i = 0; i < num_classes; ++i) {
+            if (NULL != classes[i]) {
+                free(classes[i]);
+            }
+        }
+        free(classes);
+        classes = NULL;
+        num_classes = 0;
+        max_classes = 0;
+    }
+
+    return 0;
+}
+
+
+static void save_class(pmix_class_t *cls)
+{
+    if (num_classes >= max_classes) {
+        expand_array();
+    }
+
+    classes[num_classes] = cls->cls_construct_array;
+    ++num_classes;
+}
+
+
+static void expand_array(void)
+{
+    int i;
+
+    max_classes += increment;
+    if (NULL == classes) {
+        classes = (void**)calloc(max_classes, sizeof(void*));
+    } else {
+        classes = (void**)realloc(classes, sizeof(void *) * max_classes);
+    }
+    if (NULL == classes) {
+        perror("class malloc failed");
+        exit(-1);
+    }
+    for (i = num_classes; i < max_classes; ++i) {
+        classes[i] = NULL;
+    }
+}

--- a/unit/pmix_object.h
+++ b/unit/pmix_object.h
@@ -1,0 +1,456 @@
+/* -*- Mode: C; c-basic-offset:4 ; -*- */
+/*
+ * Copyright (c) 2004-2005 The Trustees of Indiana University and Indiana
+ *                         University Research and Technology
+ *                         Corporation.  All rights reserved.
+ * Copyright (c) 2004-2007 The University of Tennessee and The University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
+ * Copyright (c) 2004-2006 High Performance Computing Center Stuttgart,
+ *                         University of Stuttgart.  All rights reserved.
+ * Copyright (c) 2004-2005 The Regents of the University of California.
+ *                         All rights reserved.
+ * Copyright (c) 2007      Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2013-2019 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2016      Research Organization for Information Science
+ *                         and Technology (RIST). All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+
+/**
+ * @file:
+ *
+ * A simple C-language object-oriented system with single inheritance
+ * and ownership-based memory management using a retain/release model.
+ *
+ * A class consists of a struct and singly-instantiated class
+ * descriptor.  The first element of the struct must be the parent
+ * class's struct.  The class descriptor must be given a well-known
+ * name based upon the class struct name (if the struct is sally_t,
+ * the class descriptor should be sally_t_class) and must be
+ * statically initialized as discussed below.
+ *
+ * (a) To define a class
+ *
+ * In a interface (.h) file, define the class.  The first element
+ * should always be the parent class, for example
+ * @code
+ *   struct sally_t
+ *   {
+ *     parent_t parent;
+ *     void *first_member;
+ *     ...
+ *   };
+ *   typedef struct sally_t sally_t;
+ *
+ *   PMIX_CLASS_DECLARATION(sally_t);
+ * @endcode
+ * All classes must have a parent which is also class.
+ *
+ * In an implementation (.c) file, instantiate a class descriptor for
+ * the class like this:
+ * @code
+ *   PMIX_CLASS_INSTANCE(sally_t, parent_t, sally_construct, sally_destruct);
+ * @endcode
+ * This macro actually expands to
+ * @code
+ *   pmix_class_t sally_t_class = {
+ *     "sally_t",
+ *     PMIX_CLASS(parent_t),  // pointer to parent_t_class
+ *     sally_construct,
+ *     sally_destruct,
+ *     0, 0, NULL, NULL,
+ *     sizeof ("sally_t")
+ *   };
+ * @endcode
+ * This variable should be declared in the interface (.h) file using
+ * the PMIX_CLASS_DECLARATION macro as shown above.
+ *
+ * sally_construct, and sally_destruct are function pointers to the
+ * constructor and destructor for the class and are best defined as
+ * static functions in the implementation file.  NULL pointers maybe
+ * supplied instead.
+ *
+ * Other class methods may be added to the struct.
+ *
+ * (b) Class instantiation: dynamic
+ *
+ * To create a instance of a class (an object) use PMIX_NEW:
+ * @code
+ *   sally_t *sally = PMIX_NEW(sally_t);
+ * @endcode
+ * which allocates memory of sizeof(sally_t) and runs the class's
+ * constructors.
+ *
+ * Use PMIX_RETAIN, PMIX_RELEASE to do reference-count-based
+ * memory management:
+ * @code
+ *   PMIX_RETAIN(sally);
+ *   PMIX_RELEASE(sally);
+ *   PMIX_RELEASE(sally);
+ * @endcode
+ * When the reference count reaches zero, the class's destructor, and
+ * those of its parents, are run and the memory is freed.
+ *
+ * N.B. There is no explicit free/delete method for dynamic objects in
+ * this model.
+ *
+ * (c) Class instantiation: static
+ *
+ * For an object with static (or stack) allocation, it is only
+ * necessary to initialize the memory, which is done using
+ * PMIX_CONSTRUCT:
+ * @code
+ *   sally_t sally;
+ *
+ *   PMIX_CONSTRUCT(&sally, sally_t);
+ * @endcode
+ * The retain/release model is not necessary here, but before the
+ * object goes out of scope, PMIX_DESTRUCT should be run to release
+ * initialized resources:
+ * @code
+ *   PMIX_DESTRUCT(&sally);
+ * @endcode
+ */
+
+#ifndef PMIX_OBJECT_H
+#define PMIX_OBJECT_H
+
+#include <pmix_common.h>
+
+#include <assert.h>
+#include <stdlib.h>
+
+
+/* Any kind of unique ID should do the job */
+#define PMIX_OBJ_MAGIC_ID ((0xdeafbeedULL << 32) + 0xdeafbeedULL)
+
+/* typedefs ***********************************************************/
+
+typedef struct pmix_object_t pmix_object_t;
+typedef struct pmix_class_t pmix_class_t;
+typedef void (*pmix_construct_t) (pmix_object_t *);
+typedef void (*pmix_destruct_t) (pmix_object_t *);
+
+
+/* types **************************************************************/
+
+/**
+ * Class descriptor.
+ *
+ * There should be a single instance of this descriptor for each class
+ * definition.
+ */
+struct pmix_class_t {
+    const char *cls_name;           /**< symbolic name for class */
+    pmix_class_t *cls_parent;       /**< parent class descriptor */
+    pmix_construct_t cls_construct; /**< class constructor */
+    pmix_destruct_t cls_destruct;   /**< class destructor */
+    int cls_initialized;            /**< is class initialized */
+    int cls_depth;                  /**< depth of class hierarchy tree */
+    pmix_construct_t *cls_construct_array;
+                                    /**< array of parent class constructors */
+    pmix_destruct_t *cls_destruct_array;
+                                    /**< array of parent class destructors */
+    size_t cls_sizeof;              /**< size of an object instance */
+};
+
+extern int pmix_class_init_epoch;
+
+/**
+ * For static initializations of OBJects.
+ *
+ * @param NAME   Name of the class to initialize
+ */
+#define PMIX_OBJ_STATIC_INIT(BASE_CLASS) { PMIX_OBJ_MAGIC_ID, PMIX_CLASS(BASE_CLASS), 1, __FILE__, __LINE__ }
+
+/**
+ * Base object.
+ *
+ * This is special and does not follow the pattern for other classes.
+ */
+struct pmix_object_t {
+    /** Magic ID -- want this to be the very first item in the
+        struct's memory */
+    uint64_t obj_magic_id;
+    pmix_class_t *obj_class;            /**< class descriptor */
+    int obj_reference_count;   /**< reference count */
+   const char* cls_init_file_name;        /**< In debug mode store the file where the object get contructed */
+   int   cls_init_lineno;           /**< In debug mode store the line number where the object get contructed */
+};
+
+/* macros ************************************************************/
+
+/**
+ * Return a pointer to the class descriptor associated with a
+ * class type.
+ *
+ * @param NAME          Name of class
+ * @return              Pointer to class descriptor
+ */
+#define PMIX_CLASS(NAME)     (&(NAME ## _class))
+
+
+/**
+ * Static initializer for a class descriptor
+ *
+ * @param NAME          Name of class
+ * @param PARENT        Name of parent class
+ * @param CONSTRUCTOR   Pointer to constructor
+ * @param DESTRUCTOR    Pointer to destructor
+ *
+ * Put this in NAME.c
+ */
+#define PMIX_CLASS_INSTANCE(NAME, PARENT, CONSTRUCTOR, DESTRUCTOR)       \
+    pmix_class_t NAME ## _class = {                                     \
+        # NAME,                                                         \
+        PMIX_CLASS(PARENT),                                              \
+        (pmix_construct_t) CONSTRUCTOR,                                 \
+        (pmix_destruct_t) DESTRUCTOR,                                   \
+        0, 0, NULL, NULL,                                               \
+        sizeof(NAME)                                                    \
+    }
+
+
+/**
+ * Declaration for class descriptor
+ *
+ * @param NAME          Name of class
+ *
+ * Put this in NAME.h
+ */
+#define PMIX_CLASS_DECLARATION(NAME)             \
+    extern pmix_class_t NAME ## _class
+
+
+/**
+ * Create an object: dynamically allocate storage and run the class
+ * constructor.
+ *
+ * @param type          Type (class) of the object
+ * @return              Pointer to the object
+ */
+static inline pmix_object_t *pmix_obj_new(pmix_class_t * cls);
+static inline pmix_object_t *pmix_obj_new_debug(pmix_class_t* type, const char* file, int line)
+{
+    pmix_object_t* object = pmix_obj_new(type);
+    object->obj_magic_id = PMIX_OBJ_MAGIC_ID;
+    object->cls_init_file_name = file;
+    object->cls_init_lineno = line;
+    return object;
+}
+#define PMIX_NEW(type)                                   \
+    ((type *)pmix_obj_new_debug(PMIX_CLASS(type), __FILE__, __LINE__))
+
+/**
+ * Retain an object (by incrementing its reference count)
+ *
+ * @param object        Pointer to the object
+ */
+#define PMIX_RETAIN(object)                                              \
+    do {                                                                \
+        assert(NULL != ((pmix_object_t *) (object))->obj_class);        \
+        assert(PMIX_OBJ_MAGIC_ID == ((pmix_object_t *) (object))->obj_magic_id); \
+        pmix_obj_update((pmix_object_t *) (object), 1);                 \
+        assert(((pmix_object_t *) (object))->obj_reference_count >= 0); \
+    } while (0)
+
+/**
+ * Helper macro for the debug mode to store the locations where the status of
+ * an object change.
+ */
+#define PMIX_REMEMBER_FILE_AND_LINENO( OBJECT, FILE, LINENO )    \
+    do {                                                        \
+        ((pmix_object_t*)(OBJECT))->cls_init_file_name = FILE;  \
+        ((pmix_object_t*)(OBJECT))->cls_init_lineno = LINENO;   \
+    } while (0)
+#define PMIX_SET_MAGIC_ID( OBJECT, VALUE )                       \
+    do {                                                        \
+        ((pmix_object_t*)(OBJECT))->obj_magic_id = (VALUE);     \
+    } while (0)
+
+/**
+ * Release an object (by decrementing its reference count).  If the
+ * reference count reaches zero, destruct (finalize) the object and
+ * free its storage.
+ *
+ * Note: If the object is freed, then the value of the pointer is set
+ * to NULL.
+ *
+ * @param object        Pointer to the object
+ */
+#define PMIX_RELEASE(object)                                             \
+    do {                                                                \
+        assert(NULL != ((pmix_object_t *) (object))->obj_class);        \
+        assert(PMIX_OBJ_MAGIC_ID == ((pmix_object_t *) (object))->obj_magic_id); \
+        if (0 == pmix_obj_update((pmix_object_t *) (object), -1)) {     \
+            PMIX_SET_MAGIC_ID((object), 0);                              \
+            pmix_obj_run_destructors((pmix_object_t *) (object));       \
+            PMIX_REMEMBER_FILE_AND_LINENO( object, __FILE__, __LINE__ ); \
+            free(object);                                               \
+            object = NULL;                                              \
+        }                                                               \
+    } while (0)
+
+
+/**
+ * Construct (initialize) objects that are not dynamically allocated.
+ *
+ * @param object        Pointer to the object
+ * @param type          The object type
+ */
+
+#define PMIX_CONSTRUCT(object, type)                             \
+do {                                                            \
+    PMIX_CONSTRUCT_INTERNAL((object), PMIX_CLASS(type));          \
+} while (0)
+
+#define PMIX_CONSTRUCT_INTERNAL(object, type)                        \
+do {                                                                \
+    PMIX_SET_MAGIC_ID((object), PMIX_OBJ_MAGIC_ID);              \
+    if (pmix_class_init_epoch != (type)->cls_initialized) {                             \
+        pmix_class_initialize((type));                              \
+    }                                                               \
+    ((pmix_object_t *) (object))->obj_class = (type);               \
+    ((pmix_object_t *) (object))->obj_reference_count = 1;          \
+    pmix_obj_run_constructors((pmix_object_t *) (object));          \
+    PMIX_REMEMBER_FILE_AND_LINENO( object, __FILE__, __LINE__ ); \
+} while (0)
+
+
+/**
+ * Destruct (finalize) an object that is not dynamically allocated.
+ *
+ * @param object        Pointer to the object
+ */
+#define PMIX_DESTRUCT(object)                                    \
+do {                                                            \
+    assert(PMIX_OBJ_MAGIC_ID == ((pmix_object_t *) (object))->obj_magic_id); \
+    PMIX_SET_MAGIC_ID((object), 0);                              \
+    pmix_obj_run_destructors((pmix_object_t *) (object));       \
+    PMIX_REMEMBER_FILE_AND_LINENO( object, __FILE__, __LINE__ ); \
+} while (0)
+
+PMIX_CLASS_DECLARATION(pmix_object_t);
+
+/* declarations *******************************************************/
+
+/**
+ * Lazy initialization of class descriptor.
+ *
+ * Specifically cache arrays of function pointers for the constructor
+ * and destructor hierarchies for this class.
+ *
+ * @param class    Pointer to class descriptor
+ */
+void pmix_class_initialize(pmix_class_t *);
+
+/**
+ * Shut down the class system and release all memory
+ *
+ * This function should be invoked as the ABSOLUTE LAST function to
+ * use the class subsystem.  It frees all associated memory with ALL
+ * classes, rendering all of them inoperable.  It is here so that
+ * tools like valgrind and purify don't report still-reachable memory
+ * upon process termination.
+ */
+int pmix_class_finalize(void);
+
+/**
+ * Run the hierarchy of class constructors for this object, in a
+ * parent-first order.
+ *
+ * Do not use this function directly: use PMIX_CONSTRUCT() instead.
+ *
+ * WARNING: This implementation relies on a hardwired maximum depth of
+ * the inheritance tree!!!
+ *
+ * Hardwired for fairly shallow inheritance trees
+ * @param size          Pointer to the object.
+ */
+static inline void pmix_obj_run_constructors(pmix_object_t * object)
+{
+    pmix_construct_t* cls_construct;
+
+    assert(NULL != object->obj_class);
+
+    cls_construct = object->obj_class->cls_construct_array;
+    while( NULL != *cls_construct ) {
+        (*cls_construct)(object);
+        cls_construct++;
+    }
+}
+
+
+/**
+ * Run the hierarchy of class destructors for this object, in a
+ * parent-last order.
+ *
+ * Do not use this function directly: use PMIX_DESTRUCT() instead.
+ *
+ * @param size          Pointer to the object.
+ */
+static inline void pmix_obj_run_destructors(pmix_object_t * object)
+{
+    pmix_destruct_t* cls_destruct;
+
+    assert(NULL != object->obj_class);
+
+    cls_destruct = object->obj_class->cls_destruct_array;
+    while( NULL != *cls_destruct ) {
+        (*cls_destruct)(object);
+        cls_destruct++;
+    }
+}
+
+
+/**
+ * Create new object: dynamically allocate storage and run the class
+ * constructor.
+ *
+ * Do not use this function directly: use PMIX_NEW() instead.
+ *
+ * @param size          Size of the object
+ * @param cls           Pointer to the class descriptor of this object
+ * @return              Pointer to the object
+ */
+static inline pmix_object_t *pmix_obj_new(pmix_class_t * cls)
+{
+    pmix_object_t *object;
+    assert(cls->cls_sizeof >= sizeof(pmix_object_t));
+
+    object = (pmix_object_t *) malloc(cls->cls_sizeof);
+    if (pmix_class_init_epoch != cls->cls_initialized) {
+        pmix_class_initialize(cls);
+    }
+    if (NULL != object) {
+        object->obj_class = cls;
+        object->obj_reference_count = 1;
+        pmix_obj_run_constructors(object);
+    }
+    return object;
+}
+
+
+/**
+ * Atomically update the object's reference count by some increment.
+ *
+ * This function should not be used directly: it is called via the
+ * macros PMIX_RETAIN and PMIX_RELEASE
+ *
+ * @param object        Pointer to the object
+ * @param inc           Increment by which to update reference count
+ * @return              New value of the reference count
+ */
+static inline int pmix_obj_update(pmix_object_t *object, int inc);
+static inline int pmix_obj_update(pmix_object_t *object, int inc)
+{
+    object->obj_reference_count += inc;
+    return object->obj_reference_count;
+}
+
+#endif

--- a/unit/pmix_progress_threads.h
+++ b/unit/pmix_progress_threads.h
@@ -1,0 +1,81 @@
+/*
+ * Copyright (c) 2014-2019 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2015      Cisco Systems, Inc.  All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+
+#ifndef PMIX_PROGRESS_THREADS_H
+#define PMIX_PROGRESS_THREADS_H
+
+#include <pthread.h>
+#include <event.h>
+#include "test_common.h"
+
+/**
+ * Initialize a progress thread name; if a progress thread is not
+ * already associated with that name, start a progress thread.
+ *
+ * If you have general events that need to run in *a* progress thread
+ * (but not necessarily a your own, dedicated progress thread), pass
+ * NULL the "name" argument to the pmix_progress_thead_init() function
+ * to glom on to the general PMIX-wide progress thread.
+ *
+ * If a name is passed that was already used in a prior call to
+ * pmix_progress_thread_init(), the event base associated with that
+ * already-running progress thread will be returned (i.e., no new
+ * progress thread will be started).
+ */
+struct event_base *pmix_progress_thread_init(const char *name);
+
+/**
+ * Stop a progress thread name (reference counted).
+ *
+ * Once this function is invoked as many times as
+ * pmix_progress_thread_init() was invoked on this name (or NULL), the
+ * progress function is shut down.
+ * it is destroyed.
+ *
+ * Will return PMIX_ERR_NOT_FOUND if the progress thread name does not
+ * exist; PMIX_SUCCESS otherwise.
+ */
+int pmix_progress_thread_stop(const char *name);
+
+/**
+ * Finalize a progress thread name (reference counted).
+ *
+ * Once this function is invoked after pmix_progress_thread_stop() has been called
+ * as many times as pmix_progress_thread_init() was invoked on this name (or NULL),
+ * the event base associated with it is destroyed.
+ *
+ * Will return PMIX_ERR_NOT_FOUND if the progress thread name does not
+ * exist; PMIX_SUCCESS otherwise.
+ */
+int pmix_progress_thread_finalize(const char *name);
+
+/**
+ * Temporarily pause the progress thread associated with this name.
+ *
+ * This function does not destroy the event base associated with this
+ * progress thread name, but it does stop processing all events on
+ * that event base until pmix_progress_thread_resume() is invoked on
+ * that name.
+ *
+ * Will return PMIX_ERR_NOT_FOUND if the progress thread name does not
+ * exist; PMIX_SUCCESS otherwise.
+ */
+int pmix_progress_thread_pause(const char *name);
+
+/**
+ * Restart a previously-paused progress thread associated with this
+ * name.
+ *
+ * Will return PMIX_ERR_NOT_FOUND if the progress thread name does not
+ * exist; PMIX_SUCCESS otherwise.
+ */
+int pmix_progress_thread_resume(const char *name);
+
+#endif

--- a/unit/pmix_regex.c
+++ b/unit/pmix_regex.c
@@ -28,11 +28,7 @@
 #include <stdlib.h>
 #include <unistd.h>
 
-#include "src/util/argv.h"
-#include "src/util/pmix_environ.h"
-#include "src/util/output.h"
-#include "src/server/pmix_server_ops.h"
-#include "src/mca/preg/preg.h"
+#include "argv.h"
 
 #include "server_callbacks.h"
 #include "utils.h"
@@ -64,49 +60,14 @@ int main(int argc, char **argv)
     fprintf(stderr, "NODES: %s\n", TEST_NODES);
     PMIx_generate_regex(TEST_NODES, &regex);
     fprintf(stderr, "REGEX: %s\n\n", regex);
-    /* test reverse parsing */
-    rc = pmix_preg.parse_nodes(regex, &nodes);
-    free(regex);
-    if (PMIX_SUCCESS == rc) {
-        regex = pmix_argv_join(nodes, ',');
-        pmix_argv_free(nodes);
-        fprintf(stderr, "NODES: %s\n", TEST_NODES);
-        fprintf(stderr, "RSULT: %s\n\n\n", regex);
-        free(regex);
-    } else {
-        fprintf(stderr, "Node reverse failed: %d\n\n\n", rc);
-    }
 
     fprintf(stderr, "PROCS: %s\n", TEST_PROCS);
     PMIx_generate_ppn(TEST_PROCS, &regex);
     fprintf(stderr, "PPN: %s\n\n", regex);
-    /* test reverse parsing */
-    rc = pmix_preg.parse_procs(regex, &procs);
-    free(regex);
-    if (PMIX_SUCCESS == rc) {
-        regex = pmix_argv_join(procs, ';');
-        pmix_argv_free(procs);
-        fprintf(stderr, "PROCS: %s\n", TEST_PROCS);
-        fprintf(stderr, "RSULT: %s\n", regex);
-        free(regex);
-    } else {
-        fprintf(stderr, "PPN reverse failed: %d\n", rc);
-    }
 
     fprintf(stderr, "NODES: %s\n", TEST_NODES2);
     PMIx_generate_regex(TEST_NODES2, &regex);
     fprintf(stderr, "REGEX: %s\n\n", regex);
-    /* test reverse parsing */
-    rc = pmix_preg.parse_nodes(regex, &nodes);
-    free(regex);
-    if (PMIX_SUCCESS == rc) {
-        regex = pmix_argv_join(nodes, ',');
-        pmix_argv_free(nodes);
-        fprintf(stderr, "NODES: %s\n", TEST_NODES2);
-        fprintf(stderr, "RSULT: %s\n\n\n", regex);
-        free(regex);
-    } else {
-        fprintf(stderr, "Node reverse failed: %d\n\n\n", rc);
-    }
+
     return 0;
 }

--- a/unit/pmix_regex.d
+++ b/unit/pmix_regex.d
@@ -211,7 +211,7 @@ pmix_regex.o: pmix_regex.c \
  /Users/rhc/pmix/build/clean/include/pmix/src/include/pmix_globals.h \
  /Users/rhc/pmix/build/clean/include/pmix.h \
  /Users/rhc/pmix/build/clean/include/pmix/src/class/pmix_hash_table.h \
- /Users/rhc/pmix/build/clean/include/pmix/src/class/pmix_list.h \
+ /Users/rhc/pmix/build/clean/include/pmix/src/class/unit_list.h \
  /Users/rhc/pmix/build/clean/include/pmix/src/event/pmix_event.h \
  /Users/rhc/pmix/build/clean/include/pmix/src/mca/bfrops/bfrops.h \
  /Users/rhc/pmix/build/clean/include/pmix/src/mca/mca.h \
@@ -668,7 +668,7 @@ pmix_regex.o: pmix_regex.c \
 
 /Users/rhc/pmix/build/clean/include/pmix/src/class/pmix_hash_table.h:
 
-/Users/rhc/pmix/build/clean/include/pmix/src/class/pmix_list.h:
+/Users/rhc/pmix/build/clean/include/pmix/src/class/unit_list.h:
 
 /Users/rhc/pmix/build/clean/include/pmix/src/event/pmix_event.h:
 

--- a/unit/pmix_test.c
+++ b/unit/pmix_test.c
@@ -30,9 +30,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <unistd.h>
-
-#include "src/util/pmix_environ.h"
-#include "src/util/output.h"
+extern char **environ;
 
 #include "server_callbacks.h"
 #include "utils.h"

--- a/unit/pmix_test.d
+++ b/unit/pmix_test.d
@@ -213,7 +213,7 @@ pmix_test.o: pmix_test.c \
  /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/sys/_types/_mach_port_t.h \
  /Users/rhc/pmix/build/clean/include/pmix.h \
  /Users/rhc/pmix/build/clean/include/pmix/src/class/pmix_hash_table.h \
- /Users/rhc/pmix/build/clean/include/pmix/src/class/pmix_list.h \
+ /Users/rhc/pmix/build/clean/include/pmix/src/class/unit_list.h \
  /Users/rhc/pmix/build/clean/include/pmix/src/class/pmix_hotel.h \
  /Users/rhc/pmix/build/clean/include/pmix/src/event/pmix_event.h \
  /Users/rhc/pmix/build/clean/include/pmix/src/threads/threads.h \
@@ -670,7 +670,7 @@ cli_stages.h:
 
 /Users/rhc/pmix/build/clean/include/pmix/src/class/pmix_hash_table.h:
 
-/Users/rhc/pmix/build/clean/include/pmix/src/class/pmix_list.h:
+/Users/rhc/pmix/build/clean/include/pmix/src/class/unit_list.h:
 
 /Users/rhc/pmix/build/clean/include/pmix/src/class/pmix_hotel.h:
 

--- a/unit/server_callbacks.c
+++ b/unit/server_callbacks.c
@@ -16,7 +16,6 @@
 #include <pthread.h>
 #include <stdio.h>
 #include "server_callbacks.h"
-#include "src/util/argv.h"
 #include "test_server.h"
 
 extern bool spawn_wait;
@@ -38,7 +37,7 @@ pmix_server_module_t mymodule = {
 };
 
 typedef struct {
-    pmix_list_item_t super;
+    unit_list_item_t super;
     pmix_info_t data;
     char *namespace_published;
     int rank_published;
@@ -55,10 +54,10 @@ static void tdes(pmix_test_info_t *p)
 }
 
 PMIX_CLASS_INSTANCE(pmix_test_info_t,
-                          pmix_list_item_t,
+                          unit_list_item_t,
                           tcon, tdes);
 
-pmix_list_t *pmix_test_published_list = NULL;
+unit_list_t *pmix_test_published_list = NULL;
 
 static int finalized_count = 0;
 
@@ -96,7 +95,7 @@ pmix_status_t finalized(const pmix_proc_t *proc, void *server_object,
     finalized_count++;
     if (finalized_count == cli_info_cnt) {
         if (NULL != pmix_test_published_list) {
-            PMIX_LIST_RELEASE(pmix_test_published_list);
+            UNIT_LIST_RELEASE(pmix_test_published_list);
         }
     }
     if (NULL != cbfunc) {
@@ -127,7 +126,7 @@ pmix_status_t fencenb_fn(const pmix_proc_t procs[], size_t nprocs,
     TEST_VERBOSE(("Getting data for %s:%d",
                   procs[0].nspace, procs[0].rank));
 
-    if ((pmix_list_get_size(server_list) == 1) && (my_server_id == 0)) {
+    if ((unit_list_get_size(server_list) == 1) && (my_server_id == 0)) {
         if (NULL != cbfunc) {
             cbfunc(PMIX_SUCCESS, data, ndata, cbdata, NULL, NULL);
         }
@@ -143,7 +142,7 @@ pmix_status_t dmodex_fn(const pmix_proc_t *proc,
     TEST_VERBOSE(("Getting data for %s:%d", proc->nspace, proc->rank));
 
     /* return not_found for single server mode */
-    if ((pmix_list_get_size(server_list) == 1) && (my_server_id == 0)) {
+    if ((unit_list_get_size(server_list) == 1) && (my_server_id == 0)) {
         return PMIX_ERR_NOT_FOUND;
     }
     // TODO: add support tracker for dmodex requests
@@ -158,11 +157,11 @@ pmix_status_t publish_fn(const pmix_proc_t *proc,
     int found;
     pmix_test_info_t *new_info, *old_info;
     if (NULL == pmix_test_published_list) {
-        pmix_test_published_list = PMIX_NEW(pmix_list_t);
+        pmix_test_published_list = PMIX_NEW(unit_list_t);
     }
     for (i = 0; i < ninfo; i++) {
         found = 0;
-        PMIX_LIST_FOREACH(old_info, pmix_test_published_list, pmix_test_info_t) {
+        UNIT_LIST_FOREACH(old_info, pmix_test_published_list, pmix_test_info_t) {
             if (!strcmp(old_info->data.key, info[i].key)) {
                 found = 1;
                 break;
@@ -174,7 +173,7 @@ pmix_status_t publish_fn(const pmix_proc_t *proc,
             pmix_value_xfer(&new_info->data.value, (pmix_value_t*)&info[i].value);
             new_info->namespace_published = strdup(proc->nspace);
             new_info->rank_published = proc->rank;
-            pmix_list_append(pmix_test_published_list, &new_info->super);
+            unit_list_append(pmix_test_published_list, &new_info->super);
         }
     }
     if (NULL != cbfunc) {
@@ -198,7 +197,7 @@ pmix_status_t lookup_fn(const pmix_proc_t *proc, char **keys,
     PMIX_PDATA_CREATE(pdata, ndata);
     ret = 0;
     for (i = 0; i < ndata; i++) {
-        PMIX_LIST_FOREACH(tinfo, pmix_test_published_list, pmix_test_info_t) {
+        UNIT_LIST_FOREACH(tinfo, pmix_test_published_list, pmix_test_info_t) {
             if (0 == strcmp(tinfo->data.key, keys[i])) {
                 (void)strncpy(pdata[i].proc.nspace, tinfo->namespace_published, PMIX_MAX_NSLEN);
                 pdata[i].proc.rank = tinfo->rank_published;
@@ -231,16 +230,16 @@ pmix_status_t unpublish_fn(const pmix_proc_t *proc, char **keys,
     if (NULL == pmix_test_published_list) {
         return PMIX_ERR_NOT_FOUND;
     }
-    PMIX_LIST_FOREACH_SAFE(iptr, next, pmix_test_published_list, pmix_test_info_t) {
+    UNIT_LIST_FOREACH_SAFE(iptr, next, pmix_test_published_list, pmix_test_info_t) {
         if (1) {  // if data posted by this process
             if (NULL == keys) {
-                pmix_list_remove_item(pmix_test_published_list, &iptr->super);
+                unit_list_remove_item(pmix_test_published_list, &iptr->super);
                 PMIX_RELEASE(iptr);
             } else {
                 ninfo = pmix_argv_count(keys);
                 for (i = 0; i < ninfo; i++) {
                     if (!strcmp(iptr->data.key, keys[i])) {
-                        pmix_list_remove_item(pmix_test_published_list, &iptr->super);
+                        unit_list_remove_item(pmix_test_published_list, &iptr->super);
                         PMIX_RELEASE(iptr);
                         break;
                     }

--- a/unit/server_callbacks.d
+++ b/unit/server_callbacks.d
@@ -211,7 +211,7 @@ server_callbacks.o: server_callbacks.c \
  /Users/rhc/pmix/build/clean/include/pmix/src/include/prefetch.h \
  /Users/rhc/pmix/build/clean/include/pmix.h \
  /Users/rhc/pmix/build/clean/include/pmix/src/class/pmix_hash_table.h \
- /Users/rhc/pmix/build/clean/include/pmix/src/class/pmix_list.h \
+ /Users/rhc/pmix/build/clean/include/pmix/src/class/unit_list.h \
  /Users/rhc/pmix/build/clean/include/pmix/src/class/pmix_hotel.h \
  /Users/rhc/pmix/build/clean/include/pmix/src/event/pmix_event.h \
  /Users/rhc/pmix/build/clean/include/pmix/src/threads/threads.h \
@@ -664,7 +664,7 @@ cli_stages.h:
 
 /Users/rhc/pmix/build/clean/include/pmix/src/class/pmix_hash_table.h:
 
-/Users/rhc/pmix/build/clean/include/pmix/src/class/pmix_list.h:
+/Users/rhc/pmix/build/clean/include/pmix/src/class/unit_list.h:
 
 /Users/rhc/pmix/build/clean/include/pmix/src/class/pmix_hotel.h:
 

--- a/unit/test_cd.d
+++ b/unit/test_cd.d
@@ -201,7 +201,7 @@ test_cd.o: test_cd.c test_cd.h \
  /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/sys/qos.h \
  /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/sys/_types/_mach_port_t.h \
  /Users/rhc/pmix/build/clean/include/pmix/src/class/pmix_hash_table.h \
- /Users/rhc/pmix/build/clean/include/pmix/src/class/pmix_list.h \
+ /Users/rhc/pmix/build/clean/include/pmix/src/class/unit_list.h \
  /Users/rhc/pmix/build/clean/include/pmix/src/class/pmix_hotel.h \
  /Users/rhc/pmix/build/clean/include/pmix/src/event/pmix_event.h \
  /Users/rhc/pmix/build/clean/include/pmix/src/threads/threads.h \
@@ -635,7 +635,7 @@ test_common.h:
 
 /Users/rhc/pmix/build/clean/include/pmix/src/class/pmix_hash_table.h:
 
-/Users/rhc/pmix/build/clean/include/pmix/src/class/pmix_list.h:
+/Users/rhc/pmix/build/clean/include/pmix/src/class/unit_list.h:
 
 /Users/rhc/pmix/build/clean/include/pmix/src/class/pmix_hotel.h:
 

--- a/unit/test_cd.h
+++ b/unit/test_cd.h
@@ -8,7 +8,6 @@
  *
  */
 
-#include <src/include/pmix_config.h>
 #include <pmix.h>
 
 #include "test_common.h"

--- a/unit/test_common.d
+++ b/unit/test_common.d
@@ -201,7 +201,7 @@ test_common.o: test_common.c \
  /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/sys/_types/_mach_port_t.h \
  /Users/rhc/pmix/build/clean/include/pmix.h \
  /Users/rhc/pmix/build/clean/include/pmix/src/class/pmix_hash_table.h \
- /Users/rhc/pmix/build/clean/include/pmix/src/class/pmix_list.h \
+ /Users/rhc/pmix/build/clean/include/pmix/src/class/unit_list.h \
  /Users/rhc/pmix/build/clean/include/pmix/src/class/pmix_hotel.h \
  /Users/rhc/pmix/build/clean/include/pmix/src/event/pmix_event.h \
  /Users/rhc/pmix/build/clean/include/pmix/src/threads/threads.h \
@@ -637,7 +637,7 @@ test_common.h:
 
 /Users/rhc/pmix/build/clean/include/pmix/src/class/pmix_hash_table.h:
 
-/Users/rhc/pmix/build/clean/include/pmix/src/class/pmix_list.h:
+/Users/rhc/pmix/build/clean/include/pmix/src/class/unit_list.h:
 
 /Users/rhc/pmix/build/clean/include/pmix/src/class/pmix_hotel.h:
 

--- a/unit/test_error.d
+++ b/unit/test_error.d
@@ -202,7 +202,7 @@ test_error.o: test_error.c \
  /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/sys/qos.h \
  /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/sys/_types/_mach_port_t.h \
  /Users/rhc/pmix/build/clean/include/pmix/src/class/pmix_hash_table.h \
- /Users/rhc/pmix/build/clean/include/pmix/src/class/pmix_list.h \
+ /Users/rhc/pmix/build/clean/include/pmix/src/class/unit_list.h \
  /Users/rhc/pmix/build/clean/include/pmix/src/class/pmix_hotel.h \
  /Users/rhc/pmix/build/clean/include/pmix/src/event/pmix_event.h \
  /Users/rhc/pmix/build/clean/include/pmix/src/threads/threads.h \
@@ -636,7 +636,7 @@ test_common.h:
 
 /Users/rhc/pmix/build/clean/include/pmix/src/class/pmix_hash_table.h:
 
-/Users/rhc/pmix/build/clean/include/pmix/src/class/pmix_list.h:
+/Users/rhc/pmix/build/clean/include/pmix/src/class/unit_list.h:
 
 /Users/rhc/pmix/build/clean/include/pmix/src/class/pmix_hotel.h:
 

--- a/unit/test_error.h
+++ b/unit/test_error.h
@@ -8,7 +8,6 @@
  *
  */
 
-#include <src/include/pmix_config.h>
 #include <pmix.h>
 
 #include "test_common.h"

--- a/unit/test_fence.d
+++ b/unit/test_fence.d
@@ -201,7 +201,7 @@ test_fence.o: test_fence.c test_fence.h \
  /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/sys/qos.h \
  /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/sys/_types/_mach_port_t.h \
  /Users/rhc/pmix/build/clean/include/pmix/src/class/pmix_hash_table.h \
- /Users/rhc/pmix/build/clean/include/pmix/src/class/pmix_list.h \
+ /Users/rhc/pmix/build/clean/include/pmix/src/class/unit_list.h \
  /Users/rhc/pmix/build/clean/include/pmix/src/class/pmix_hotel.h \
  /Users/rhc/pmix/build/clean/include/pmix/src/event/pmix_event.h \
  /Users/rhc/pmix/build/clean/include/pmix/src/threads/threads.h \
@@ -635,7 +635,7 @@ test_common.h:
 
 /Users/rhc/pmix/build/clean/include/pmix/src/class/pmix_hash_table.h:
 
-/Users/rhc/pmix/build/clean/include/pmix/src/class/pmix_list.h:
+/Users/rhc/pmix/build/clean/include/pmix/src/class/unit_list.h:
 
 /Users/rhc/pmix/build/clean/include/pmix/src/class/pmix_hotel.h:
 

--- a/unit/test_fence.h
+++ b/unit/test_fence.h
@@ -10,7 +10,6 @@
  *
  */
 
-#include <src/include/pmix_config.h>
 #include <pmix.h>
 
 #include <time.h>

--- a/unit/test_internal.d
+++ b/unit/test_internal.d
@@ -201,7 +201,7 @@ test_internal.o: test_internal.c test_internal.h \
  /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/sys/qos.h \
  /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/sys/_types/_mach_port_t.h \
  /Users/rhc/pmix/build/clean/include/pmix/src/class/pmix_hash_table.h \
- /Users/rhc/pmix/build/clean/include/pmix/src/class/pmix_list.h \
+ /Users/rhc/pmix/build/clean/include/pmix/src/class/unit_list.h \
  /Users/rhc/pmix/build/clean/include/pmix/src/class/pmix_hotel.h \
  /Users/rhc/pmix/build/clean/include/pmix/src/event/pmix_event.h \
  /Users/rhc/pmix/build/clean/include/pmix/src/threads/threads.h \
@@ -635,7 +635,7 @@ test_common.h:
 
 /Users/rhc/pmix/build/clean/include/pmix/src/class/pmix_hash_table.h:
 
-/Users/rhc/pmix/build/clean/include/pmix/src/class/pmix_list.h:
+/Users/rhc/pmix/build/clean/include/pmix/src/class/unit_list.h:
 
 /Users/rhc/pmix/build/clean/include/pmix/src/class/pmix_hotel.h:
 

--- a/unit/test_internal.h
+++ b/unit/test_internal.h
@@ -10,7 +10,6 @@
  *
  */
 
-#include <src/include/pmix_config.h>
 #include <pmix.h>
 
 #include "test_common.h"

--- a/unit/test_publish.c
+++ b/unit/test_publish.c
@@ -12,7 +12,6 @@
 
 #include "test_publish.h"
 #include <time.h>
-#include <src/include/pmix_globals.h>
 
 typedef struct {
     int in_progress;

--- a/unit/test_publish.d
+++ b/unit/test_publish.d
@@ -201,7 +201,7 @@ test_publish.o: test_publish.c test_publish.h \
  /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/sys/qos.h \
  /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/sys/_types/_mach_port_t.h \
  /Users/rhc/pmix/build/clean/include/pmix/src/class/pmix_hash_table.h \
- /Users/rhc/pmix/build/clean/include/pmix/src/class/pmix_list.h \
+ /Users/rhc/pmix/build/clean/include/pmix/src/class/unit_list.h \
  /Users/rhc/pmix/build/clean/include/pmix/src/class/pmix_hotel.h \
  /Users/rhc/pmix/build/clean/include/pmix/src/event/pmix_event.h \
  /Users/rhc/pmix/build/clean/include/pmix/src/threads/threads.h \
@@ -635,7 +635,7 @@ test_common.h:
 
 /Users/rhc/pmix/build/clean/include/pmix/src/class/pmix_hash_table.h:
 
-/Users/rhc/pmix/build/clean/include/pmix/src/class/pmix_list.h:
+/Users/rhc/pmix/build/clean/include/pmix/src/class/unit_list.h:
 
 /Users/rhc/pmix/build/clean/include/pmix/src/class/pmix_hotel.h:
 

--- a/unit/test_publish.h
+++ b/unit/test_publish.h
@@ -10,7 +10,6 @@
  *
  */
 
-#include <src/include/pmix_config.h>
 #include <pmix.h>
 
 #include "test_common.h"

--- a/unit/test_replace.c
+++ b/unit/test_replace.c
@@ -31,7 +31,7 @@ static void get_cb(pmix_status_t status, pmix_value_t *kv, void *cbdata)
 static int key_is_replace(int key_idx) {
     key_replace_t *item;
 
-    PMIX_LIST_FOREACH(item, &key_replace, key_replace_t) {
+    UNIT_LIST_FOREACH(item, &key_replace, key_replace_t) {
         if (item->key_idx == key_idx)
             return 1;
     }
@@ -46,7 +46,7 @@ int test_replace(char *my_nspace, pmix_rank_t my_rank, test_params params) {
     pmix_status_t rc;
     key_replace_t *item;
 
-    PMIX_CONSTRUCT(&key_replace, pmix_list_t);
+    PMIX_CONSTRUCT(&key_replace, unit_list_t);
     parse_replace(params.key_replace, 1, &key_cnt);
 
     for (key_idx = 0; key_idx < key_cnt; key_idx++) {
@@ -56,7 +56,7 @@ int test_replace(char *my_nspace, pmix_rank_t my_rank, test_params params) {
         PUT(string, sval, PMIX_GLOBAL, 0, key_idx, 1);
         if (PMIX_SUCCESS != rc) {
             TEST_ERROR(("%s:%d: PMIx_Put failed: %d", my_nspace, my_rank, rc));
-            PMIX_LIST_DESTRUCT(&key_replace);
+            UNIT_LIST_DESTRUCT(&key_replace);
             return rc;
         }
     }
@@ -68,7 +68,7 @@ int test_replace(char *my_nspace, pmix_rank_t my_rank, test_params params) {
     /* Submit the data */
     if (PMIX_SUCCESS != (rc = PMIx_Commit())) {
         TEST_ERROR(("%s:%d: PMIx_Commit failed: %d", my_nspace, my_rank, rc));
-        PMIX_LIST_DESTRUCT(&key_replace);
+        UNIT_LIST_DESTRUCT(&key_replace);
         PMIX_PROC_DESTRUCT(&proc);
         return PMIX_ERROR;
     }
@@ -76,19 +76,19 @@ int test_replace(char *my_nspace, pmix_rank_t my_rank, test_params params) {
     FENCE(1, 1, (&proc), 1);
     if (PMIX_SUCCESS != rc) {
         TEST_ERROR(("%s:%d: PMIx_Fence failed: %d", my_nspace, my_rank, rc));
-        PMIX_LIST_DESTRUCT(&key_replace);
+        UNIT_LIST_DESTRUCT(&key_replace);
         PMIX_PROC_DESTRUCT(&proc);
         return rc;
     }
 
-    PMIX_LIST_FOREACH(item, &key_replace, key_replace_t) {
+    UNIT_LIST_FOREACH(item, &key_replace, key_replace_t) {
         memset(sval, 0, PMIX_MAX_NSLEN);
         sprintf(sval, "test_replace:%s:%d:%d: replaced key", my_nspace, my_rank, item->key_idx);
 
         PUT(string, sval, PMIX_GLOBAL, 0, item->key_idx, 1);
         if (PMIX_SUCCESS != rc) {
             TEST_ERROR(("%s:%d: PMIx_Put failed: %d", my_nspace, my_rank, rc));
-            PMIX_LIST_DESTRUCT(&key_replace);
+            UNIT_LIST_DESTRUCT(&key_replace);
             PMIX_PROC_DESTRUCT(&proc);
             return rc;
         }
@@ -98,7 +98,7 @@ int test_replace(char *my_nspace, pmix_rank_t my_rank, test_params params) {
     /* Submit the data */
     if (PMIX_SUCCESS != (rc = PMIx_Commit())) {
         TEST_ERROR(("%s:%d: PMIx_Commit failed: %d", my_nspace, my_rank, rc));
-        PMIX_LIST_DESTRUCT(&key_replace);
+        UNIT_LIST_DESTRUCT(&key_replace);
         PMIX_PROC_DESTRUCT(&proc);
         return PMIX_ERROR;
     }
@@ -106,7 +106,7 @@ int test_replace(char *my_nspace, pmix_rank_t my_rank, test_params params) {
     FENCE(1, 1, (&proc), 1);
     if (PMIX_SUCCESS != rc) {
         TEST_ERROR(("%s:%d: PMIx_Fence failed: %d", my_nspace, my_rank, rc));
-        PMIX_LIST_DESTRUCT(&key_replace);
+        UNIT_LIST_DESTRUCT(&key_replace);
         PMIX_PROC_DESTRUCT(&proc);
         return rc;
     }
@@ -124,13 +124,13 @@ int test_replace(char *my_nspace, pmix_rank_t my_rank, test_params params) {
         GET(string, sval, my_nspace, my_rank, 0, key_idx, 1, 1, 0);
         if (PMIX_SUCCESS != rc) {
             TEST_ERROR(("%s:%d: PMIx_Get of remote key on local proc", my_nspace, my_rank));
-            PMIX_LIST_DESTRUCT(&key_replace);
+            UNIT_LIST_DESTRUCT(&key_replace);
             PMIX_PROC_DESTRUCT(&proc);
             return PMIX_ERROR;
         }
     }
 
-    PMIX_LIST_DESTRUCT(&key_replace);
+    UNIT_LIST_DESTRUCT(&key_replace);
     PMIX_PROC_DESTRUCT(&proc);
     return PMIX_SUCCESS;
 }

--- a/unit/test_replace.d
+++ b/unit/test_replace.d
@@ -201,7 +201,7 @@ test_replace.o: test_replace.c test_replace.h \
  /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/sys/qos.h \
  /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/sys/_types/_mach_port_t.h \
  /Users/rhc/pmix/build/clean/include/pmix/src/class/pmix_hash_table.h \
- /Users/rhc/pmix/build/clean/include/pmix/src/class/pmix_list.h \
+ /Users/rhc/pmix/build/clean/include/pmix/src/class/unit_list.h \
  /Users/rhc/pmix/build/clean/include/pmix/src/class/pmix_hotel.h \
  /Users/rhc/pmix/build/clean/include/pmix/src/event/pmix_event.h \
  /Users/rhc/pmix/build/clean/include/pmix/src/threads/threads.h \
@@ -635,7 +635,7 @@ test_common.h:
 
 /Users/rhc/pmix/build/clean/include/pmix/src/class/pmix_hash_table.h:
 
-/Users/rhc/pmix/build/clean/include/pmix/src/class/pmix_list.h:
+/Users/rhc/pmix/build/clean/include/pmix/src/class/unit_list.h:
 
 /Users/rhc/pmix/build/clean/include/pmix/src/class/pmix_hotel.h:
 

--- a/unit/test_replace.h
+++ b/unit/test_replace.h
@@ -10,7 +10,6 @@
  *
  */
 
-#include <src/include/pmix_config.h>
 #include <pmix.h>
 
 #include "test_common.h"

--- a/unit/test_resolve_peers.c
+++ b/unit/test_resolve_peers.c
@@ -13,8 +13,6 @@
 #include "test_resolve_peers.h"
 #include "test_cd.h"
 
-#include "src/util/output.h"
-
 static int resolve_nspace(char *nspace, test_params params, char *my_nspace, int my_rank)
 {
     int rc;

--- a/unit/test_resolve_peers.d
+++ b/unit/test_resolve_peers.d
@@ -201,7 +201,7 @@ test_resolve_peers.o: test_resolve_peers.c test_resolve_peers.h \
  /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/sys/qos.h \
  /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/sys/_types/_mach_port_t.h \
  /Users/rhc/pmix/build/clean/include/pmix/src/class/pmix_hash_table.h \
- /Users/rhc/pmix/build/clean/include/pmix/src/class/pmix_list.h \
+ /Users/rhc/pmix/build/clean/include/pmix/src/class/unit_list.h \
  /Users/rhc/pmix/build/clean/include/pmix/src/class/pmix_hotel.h \
  /Users/rhc/pmix/build/clean/include/pmix/src/event/pmix_event.h \
  /Users/rhc/pmix/build/clean/include/pmix/src/threads/threads.h \
@@ -635,7 +635,7 @@ test_common.h:
 
 /Users/rhc/pmix/build/clean/include/pmix/src/class/pmix_hash_table.h:
 
-/Users/rhc/pmix/build/clean/include/pmix/src/class/pmix_list.h:
+/Users/rhc/pmix/build/clean/include/pmix/src/class/unit_list.h:
 
 /Users/rhc/pmix/build/clean/include/pmix/src/class/pmix_hotel.h:
 

--- a/unit/test_resolve_peers.h
+++ b/unit/test_resolve_peers.h
@@ -10,7 +10,6 @@
  *
  */
 
-#include <src/include/pmix_config.h>
 #include <pmix.h>
 
 #include "test_common.h"

--- a/unit/test_server.d
+++ b/unit/test_server.d
@@ -202,7 +202,7 @@ test_server.o: test_server.c \
  /Users/rhc/pmix/build/clean/include/pmix/src/include/prefetch.h \
  /Users/rhc/pmix/build/clean/include/pmix.h \
  /Users/rhc/pmix/build/clean/include/pmix/src/class/pmix_hash_table.h \
- /Users/rhc/pmix/build/clean/include/pmix/src/class/pmix_list.h \
+ /Users/rhc/pmix/build/clean/include/pmix/src/class/unit_list.h \
  /Users/rhc/pmix/build/clean/include/pmix/src/class/pmix_hotel.h \
  /Users/rhc/pmix/build/clean/include/pmix/src/event/pmix_event.h \
  /Users/rhc/pmix/build/clean/include/pmix/src/threads/threads.h \
@@ -644,7 +644,7 @@ test_server.o: test_server.c \
 
 /Users/rhc/pmix/build/clean/include/pmix/src/class/pmix_hash_table.h:
 
-/Users/rhc/pmix/build/clean/include/pmix/src/class/pmix_list.h:
+/Users/rhc/pmix/build/clean/include/pmix/src/class/unit_list.h:
 
 /Users/rhc/pmix/build/clean/include/pmix/src/class/pmix_hotel.h:
 

--- a/unit/test_server.h
+++ b/unit/test_server.h
@@ -36,7 +36,9 @@ typedef struct {
 
 struct server_info_t
 {
-    pmix_list_item_t super;
+    unit_list_item_t super;
+    char *name;
+    struct event_base *evbase;
     pid_t pid;
     int idx;
     int rd_fd;
@@ -51,7 +53,7 @@ PMIX_EXPORT PMIX_CLASS_DECLARATION(server_info_t);
 
 struct server_nspace_t
 {
-    pmix_list_item_t super;
+    unit_list_item_t super;
     char name[PMIX_MAX_NSLEN+1];
     size_t ntasks; /* total number of tasks in this namespace */
     size_t ltasks; /* local */
@@ -61,9 +63,9 @@ typedef struct server_nspace_t server_nspace_t;
 PMIX_EXPORT PMIX_CLASS_DECLARATION(server_nspace_t);
 
 extern int my_server_id;
-extern pmix_list_t *server_list;
+extern unit_list_t *server_list;
 extern server_info_t *my_server_info;
-extern pmix_list_t *server_nspace;
+extern unit_list_t *server_nspace;
 
 int server_init(test_params *params);
 int server_finalize(test_params *params, int local_fail);

--- a/unit/test_spawn.d
+++ b/unit/test_spawn.d
@@ -201,7 +201,7 @@ test_spawn.o: test_spawn.c test_spawn.h \
  /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/sys/qos.h \
  /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/sys/_types/_mach_port_t.h \
  /Users/rhc/pmix/build/clean/include/pmix/src/class/pmix_hash_table.h \
- /Users/rhc/pmix/build/clean/include/pmix/src/class/pmix_list.h \
+ /Users/rhc/pmix/build/clean/include/pmix/src/class/unit_list.h \
  /Users/rhc/pmix/build/clean/include/pmix/src/class/pmix_hotel.h \
  /Users/rhc/pmix/build/clean/include/pmix/src/event/pmix_event.h \
  /Users/rhc/pmix/build/clean/include/pmix/src/threads/threads.h \
@@ -635,7 +635,7 @@ test_common.h:
 
 /Users/rhc/pmix/build/clean/include/pmix/src/class/pmix_hash_table.h:
 
-/Users/rhc/pmix/build/clean/include/pmix/src/class/pmix_list.h:
+/Users/rhc/pmix/build/clean/include/pmix/src/class/unit_list.h:
 
 /Users/rhc/pmix/build/clean/include/pmix/src/class/pmix_hotel.h:
 

--- a/unit/test_spawn.h
+++ b/unit/test_spawn.h
@@ -10,7 +10,6 @@
  *
  */
 
-#include <src/include/pmix_config.h>
 #include <pmix.h>
 
 #include "test_common.h"

--- a/unit/unit_list.c
+++ b/unit/unit_list.c
@@ -1,0 +1,246 @@
+/* -*- Mode: C; c-basic-offset:4 ; -*- */
+/*
+ * Copyright (c) 2004-2005 The Trustees of Indiana University and Indiana
+ *                         University Research and Technology
+ *                         Corporation.  All rights reserved.
+ * Copyright (c) 2004-2006 The University of Tennessee and The University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
+ * Copyright (c) 2004-2007 High Performance Computing Center Stuttgart,
+ *                         University of Stuttgart.  All rights reserved.
+ * Copyright (c) 2004-2005 The Regents of the University of California.
+ *                         All rights reserved.
+ * Copyright (c) 2007      Voltaire All rights reserved.
+ * Copyright (c) 2013-2019 Intel, Inc.  All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+
+#include "pmix_common.h"
+#include "unit_list.h"
+
+/*
+ *  List classes
+ */
+
+static void unit_list_item_construct(unit_list_item_t*);
+static void unit_list_item_destruct(unit_list_item_t*);
+
+PMIX_CLASS_INSTANCE(
+    unit_list_item_t,
+    pmix_object_t,
+    unit_list_item_construct,
+    unit_list_item_destruct
+);
+
+static void unit_list_construct(unit_list_t*);
+static void unit_list_destruct(unit_list_t*);
+
+PMIX_CLASS_INSTANCE(
+    unit_list_t,
+    pmix_object_t,
+    unit_list_construct,
+    unit_list_destruct
+);
+
+
+/*
+ *
+ *      unit_list_link_item_t interface
+ *
+ */
+
+static void unit_list_item_construct(unit_list_item_t *item)
+{
+    item->unit_list_next = item->unit_list_prev = NULL;
+    item->item_free = 1;
+    item->unit_list_item_refcount = 0;
+    item->unit_list_item_belong_to = NULL;
+}
+
+static void unit_list_item_destruct(unit_list_item_t *item)
+{
+    assert( 0 == item->unit_list_item_refcount );
+    assert( NULL == item->unit_list_item_belong_to );
+}
+
+
+/*
+ *
+ *      unit_list_list_t interface
+ *
+ */
+
+static void unit_list_construct(unit_list_t *list)
+{
+    /* These refcounts should never be used in assertions because they
+       should never be removed from this list, added to another list,
+       etc.  So set them to sentinel values. */
+
+    PMIX_CONSTRUCT( &(list->unit_list_sentinel), unit_list_item_t );
+    list->unit_list_sentinel.unit_list_item_refcount  = 1;
+    list->unit_list_sentinel.unit_list_item_belong_to = list;
+
+    list->unit_list_sentinel.unit_list_next = &list->unit_list_sentinel;
+    list->unit_list_sentinel.unit_list_prev = &list->unit_list_sentinel;
+    list->unit_list_length = 0;
+}
+
+
+/*
+ * Reset all the pointers to be NULL -- do not actually destroy
+ * anything.
+ */
+static void unit_list_destruct(unit_list_t *list)
+{
+    unit_list_construct(list);
+}
+
+
+/*
+ * Insert an item at a specific place in a list
+ */
+bool unit_list_insert(unit_list_t *list, unit_list_item_t *item, long long idx)
+{
+    /* Adds item to list at index and retains item. */
+    int     i;
+    volatile unit_list_item_t *ptr, *next;
+
+    if ( idx >= (long long)list->unit_list_length ) {
+        return false;
+    }
+
+    if ( 0 == idx )
+    {
+        unit_list_prepend(list, item);
+    } else {
+        /* Spot check: ensure that this item is previously on no
+           lists */
+
+        assert(0 == item->unit_list_item_refcount);
+        /* pointer to element 0 */
+        ptr = list->unit_list_sentinel.unit_list_next;
+        for ( i = 0; i < idx-1; i++ )
+            ptr = ptr->unit_list_next;
+
+        next = ptr->unit_list_next;
+        item->unit_list_next = next;
+        item->unit_list_prev = ptr;
+        next->unit_list_prev = item;
+        ptr->unit_list_next = item;
+
+        /* Spot check: ensure this item is only on the list that we
+           just insertted it into */
+
+        item->unit_list_item_refcount += 1;
+        assert(1 == item->unit_list_item_refcount);
+        item->unit_list_item_belong_to = list;
+    }
+
+    list->unit_list_length++;
+    return true;
+}
+
+
+static
+void
+unit_list_transfer(unit_list_item_t *pos, unit_list_item_t *begin,
+                   unit_list_item_t *end)
+{
+    volatile unit_list_item_t *tmp;
+
+    if (pos != end) {
+        /* remove [begin, end) */
+        end->unit_list_prev->unit_list_next = pos;
+        begin->unit_list_prev->unit_list_next = end;
+        pos->unit_list_prev->unit_list_next = begin;
+
+        /* splice into new position before pos */
+        tmp = pos->unit_list_prev;
+        pos->unit_list_prev = end->unit_list_prev;
+        end->unit_list_prev = begin->unit_list_prev;
+        begin->unit_list_prev = tmp;
+        {
+            volatile unit_list_item_t* item = begin;
+            while( pos != item ) {
+                item->unit_list_item_belong_to = pos->unit_list_item_belong_to;
+                item = item->unit_list_next;
+                assert(NULL != item);
+            }
+        }
+    }
+}
+
+
+void
+unit_list_join(unit_list_t *thislist, unit_list_item_t *pos,
+               unit_list_t *xlist)
+{
+    if (0 != unit_list_get_size(xlist)) {
+        unit_list_transfer(pos, unit_list_get_first(xlist),
+                           unit_list_get_end(xlist));
+
+        /* fix the sizes */
+        thislist->unit_list_length += xlist->unit_list_length;
+        xlist->unit_list_length = 0;
+    }
+}
+
+
+void
+unit_list_splice(unit_list_t *thislist, unit_list_item_t *pos,
+                 unit_list_t *xlist, unit_list_item_t *first,
+                 unit_list_item_t *last)
+{
+    size_t change = 0;
+    unit_list_item_t *tmp;
+
+    if (first != last) {
+        /* figure out how many things we are going to move (have to do
+         * first, since last might be end and then we wouldn't be able
+         * to run the loop)
+         */
+        for (tmp = first ; tmp != last ; tmp = unit_list_get_next(tmp)) {
+            change++;
+        }
+
+        unit_list_transfer(pos, first, last);
+
+        /* fix the sizes */
+        thislist->unit_list_length += change;
+        xlist->unit_list_length -= change;
+    }
+}
+
+
+int unit_list_sort(unit_list_t* list, unit_list_item_compare_fn_t compare)
+{
+    unit_list_item_t* item;
+    unit_list_item_t** items;
+    size_t i, index=0;
+
+    if (0 == list->unit_list_length) {
+        return PMIX_SUCCESS;
+    }
+    items = (unit_list_item_t**)malloc(sizeof(unit_list_item_t*) *
+                                       list->unit_list_length);
+
+    if (NULL == items) {
+        return PMIX_ERR_OUT_OF_RESOURCE;
+    }
+
+    while(NULL != (item = unit_list_remove_first(list))) {
+        items[index++] = item;
+    }
+
+    qsort(items, index, sizeof(unit_list_item_t*),
+          (int(*)(const void*,const void*))compare);
+    for (i=0; i<index; i++) {
+        unit_list_append(list,items[i]);
+    }
+    free(items);
+    return PMIX_SUCCESS;
+}

--- a/unit/unit_list.h
+++ b/unit/unit_list.h
@@ -1,0 +1,879 @@
+/* -*- Mode: C; c-basic-offset:4 ; -*- */
+ /*
+ * Copyright (c) 2004-2005 The Trustees of Indiana University and Indiana
+ *                         University Research and Technology
+ *                         Corporation.  All rights reserved.
+ * Copyright (c) 2004-2006 The University of Tennessee and The University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
+ * Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
+ *                         University of Stuttgart.  All rights reserved.
+ * Copyright (c) 2004-2005 The Regents of the University of California.
+ *                         All rights reserved.
+ * Copyright (c) 2007      Voltaire All rights reserved.
+ * Copyright (c) 2013      Los Alamos National Security, LLC. All rights
+ *                         reserved.
+ * Copyright (c) 2013-2019 Intel, Inc.  All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+/**
+ * @file
+ *
+ * The unit_list_t interface is used to provide a generic
+ * doubly-linked list container for PMIx.  It was inspired by (but
+ * is slightly different than) the Standard Template Library (STL)
+ * std::list class.  One notable difference from std::list is that
+ * when an unit_list_t is destroyed, all of the unit_list_item_t
+ * objects that it contains are orphaned -- they are \em not
+ * destroyed.
+ *
+ * The general idea is that unit_list_item_t objects can be put on an
+ * unit_list_t.  Hence, you create a new type that derives from
+ * unit_list_item_t; this new type can then be used with unit_list_t
+ * containers.
+ *
+ * NOTE: unit_list_item_t instances can only be on \em one list at a
+ * time.  Specifically, if you add an unit_list_item_t to one list,
+ * and then add it to another list (without first removing it from the
+ * first list), you will effectively be hosing the first list.  You
+ * have been warned.
+ *
+ * If PMIX_ENABLE_DEBUG is true, a bunch of checks occur, including
+ * some spot checks for a debugging reference count in an attempt to
+ * ensure that an unit_list_item_t is only one *one* list at a time.
+ * Given the highly concurrent nature of this class, these spot checks
+ * cannot guarantee that an item is only one list at a time.
+ * Specifically, since it is a desirable attribute of this class to
+ * not use locks for normal operations, it is possible that two
+ * threads may [erroneously] modify an unit_list_item_t concurrently.
+ *
+ * The only way to guarantee that a debugging reference count is valid
+ * for the duration of an operation is to lock the item_t during the
+ * operation.  But this fundamentally changes the desirable attribute
+ * of this class (i.e., no locks).  So all we can do is spot-check the
+ * reference count in a bunch of places and check that it is still the
+ * value that we think it should be.  But this doesn't mean that you
+ * can run into "unlucky" cases where two threads are concurrently
+ * modifying an item_t, but all the spot checks still return the
+ * "right" values.  All we can do is hope that we have enough spot
+ * checks to statistically drive down the possibility of the unlucky
+ * cases happening.
+ */
+
+#ifndef UNIT_LIST_H
+#define UNIT_LIST_H
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <stdbool.h>
+
+#include "pmix_object.h"
+
+/**
+ * \internal
+ *
+ * The class for the list container.
+ */
+PMIX_CLASS_DECLARATION(unit_list_t);
+/**
+ * \internal
+ *
+ * Base class for items that are put in list (unit_list_t) containers.
+ */
+PMIX_CLASS_DECLARATION(unit_list_item_t);
+
+
+/**
+ * \internal
+ *
+ * Struct of an unit_list_item_t
+ */
+struct unit_list_item_t
+{
+    pmix_object_t super;
+    /**< Generic parent class for all PMIx objects */
+    volatile struct unit_list_item_t *unit_list_next;
+    /**< Pointer to next list item */
+    volatile struct unit_list_item_t *unit_list_prev;
+    /**< Pointer to previous list item */
+    int32_t item_free;
+
+    /** Atomic reference count for debugging */
+    int unit_list_item_refcount;
+    /** The list this item belong to */
+    volatile struct unit_list_t* unit_list_item_belong_to;
+};
+/**
+ * Base type for items that are put in a list (unit_list_t) containers.
+ */
+typedef struct unit_list_item_t unit_list_item_t;
+
+/* static initializer for unit_list_t */
+#define UNIT_LIST_ITEM_STATIC_INIT                      \
+    {                                                   \
+        .super = PMIX_OBJ_STATIC_INIT(pmix_object_t),   \
+        .unit_list_next = NULL,                         \
+        .unit_list_prev = NULL,                         \
+        .item_free = 0                                  \
+    }
+
+/**
+ * Get the next item in a list.
+ *
+ * @param item A list item.
+ *
+ * @returns The next item in the list
+ */
+#define unit_list_get_next(item) \
+    ((item) ? ((unit_list_item_t*) ((unit_list_item_t*)(item))->unit_list_next) : NULL)
+
+/**
+ * Get the next item in a list.
+ *
+ * @param item A list item.
+ *
+ * @returns The next item in the list
+ */
+#define unit_list_get_prev(item) \
+    ((item) ? ((unit_list_item_t*) ((unit_list_item_t*)(item))->unit_list_prev) : NULL)
+
+
+/**
+ * \internal
+ *
+ * Struct of an unit_list_t
+ */
+struct unit_list_t
+{
+    pmix_object_t       super;
+    /**< Generic parent class for all PMIx objects */
+    unit_list_item_t    unit_list_sentinel;
+    /**< Head and tail item of the list */
+    volatile size_t     unit_list_length;
+    /**< Quick reference to the number of items in the list */
+};
+/**
+ * List container type.
+ */
+typedef struct unit_list_t unit_list_t;
+
+/* static initializer for unit_list_t */
+#define UNIT_LIST_STATIC_INIT                                           \
+    {                                                                   \
+        .super = PMIX_OBJ_STATIC_INIT(pmix_object_t),                   \
+        .unit_list_sentinel = UNIT_LIST_ITEM_STATIC_INIT,   \
+        .unit_list_length = 0                                           \
+    }
+
+
+/** Cleanly destruct a list
+ *
+ * The unit_list_t destructor doesn't release the items on the
+ * list - so provide two convenience macros that do so and then
+ * destruct/release the list object itself
+ *
+ * @param[in] list List to destruct or release
+ */
+#define UNIT_LIST_DESTRUCT(list)                                \
+    do {                                                        \
+        unit_list_item_t *it;                                   \
+        while (NULL != (it = unit_list_remove_first(list))) {   \
+            PMIX_RELEASE(it);                                    \
+        }                                                       \
+        PMIX_DESTRUCT(list);                                     \
+    } while (0)
+
+#define UNIT_LIST_RELEASE(list)                                 \
+    do {                                                        \
+        unit_list_item_t *it;                                   \
+        while (NULL != (it = unit_list_remove_first(list))) {   \
+            PMIX_RELEASE(it);                                    \
+        }                                                       \
+        PMIX_RELEASE(list);                                      \
+    } while (0)
+
+
+/**
+ * Loop over a list.
+ *
+ * @param[in] item Storage for each item
+ * @param[in] list List to iterate over
+ * @param[in] type Type of each list item
+ *
+ * This macro provides a simple way to loop over the items in an unit_list_t. It
+ * is not safe to call unit_list_remove_item from within the loop.
+ *
+ * Example Usage:
+ *
+ * class_foo_t *foo;
+ * unit_list_foreach(foo, list, class_foo_t) {
+ *    do something;
+ * }
+ */
+#define UNIT_LIST_FOREACH(item, list, type)                             \
+  for (item = (type *) (list)->unit_list_sentinel.unit_list_next ;      \
+       item != (type *) &(list)->unit_list_sentinel ;                   \
+       item = (type *) ((unit_list_item_t *) (item))->unit_list_next)
+
+/**
+ * Loop over a list in reverse.
+ *
+ * @param[in] item Storage for each item
+ * @param[in] list List to iterate over
+ * @param[in] type Type of each list item
+ *
+ * This macro provides a simple way to loop over the items in an unit_list_t. It
+ * is not safe to call unit_list_remove_item from within the loop.
+ *
+ * Example Usage:
+ *
+ * class_foo_t *foo;
+ * unit_list_foreach(foo, list, class_foo_t) {
+ *    do something;
+ * }
+ */
+#define UNIT_LIST_FOREACH_REV(item, list, type)                         \
+  for (item = (type *) (list)->unit_list_sentinel.unit_list_prev ;      \
+       item != (type *) &(list)->unit_list_sentinel ;                   \
+       item = (type *) ((unit_list_item_t *) (item))->unit_list_prev)
+
+/**
+ * Loop over a list in a *safe* way
+ *
+ * @param[in] item Storage for each item
+ * @param[in] next Storage for next item
+ * @param[in] list List to iterate over
+ * @param[in] type Type of each list item
+ *
+ * This macro provides a simple way to loop over the items in an unit_list_t. It
+ * is safe to call unit_list_remove_item(list, item) from within the loop.
+ *
+ * Example Usage:
+ *
+ * class_foo_t *foo, *next;
+ * unit_list_foreach_safe(foo, next, list, class_foo_t) {
+ *    do something;
+ *    unit_list_remove_item (list, (unit_list_item_t *) foo);
+ * }
+ */
+#define UNIT_LIST_FOREACH_SAFE(item, next, list, type)                  \
+  for (item = (type *) (list)->unit_list_sentinel.unit_list_next,       \
+         next = (type *) ((unit_list_item_t *) (item))->unit_list_next ;\
+       item != (type *) &(list)->unit_list_sentinel ;                   \
+       item = next, next = (type *) ((unit_list_item_t *) (item))->unit_list_next)
+
+/**
+ * Loop over a list in a *safe* way
+ *
+ * @param[in] item Storage for each item
+ * @param[in] next Storage for next item
+ * @param[in] list List to iterate over
+ * @param[in] type Type of each list item
+ *
+ * This macro provides a simple way to loop over the items in an unit_list_t. If
+ * is safe to call unit_list_remove_item(list, item) from within the loop.
+ *
+ * Example Usage:
+ *
+ * class_foo_t *foo, *next;
+ * unit_list_foreach_safe(foo, next, list, class_foo_t) {
+ *    do something;
+ *    unit_list_remove_item (list, (unit_list_item_t *) foo);
+ * }
+ */
+#define UNIT_LIST_FOREACH_SAFE_REV(item, prev, list, type)              \
+  for (item = (type *) (list)->unit_list_sentinel.unit_list_prev,       \
+         prev = (type *) ((unit_list_item_t *) (item))->unit_list_prev ;\
+       item != (type *) &(list)->unit_list_sentinel ;                   \
+       item = prev, prev = (type *) ((unit_list_item_t *) (item))->unit_list_prev)
+
+
+/**
+ * Check for empty list
+ *
+ * @param list The list container
+ *
+ * @returns true if list's size is 0, false otherwise
+ *
+ * This is an O(1) operation.
+ *
+ * This is an inlined function in compilers that support inlining,
+ * so it's usually a cheap operation.
+ */
+static inline bool unit_list_is_empty(unit_list_t* list)
+{
+    return (list->unit_list_sentinel.unit_list_next ==
+        &(list->unit_list_sentinel) ? true : false);
+}
+
+
+/**
+ * Return the first item on the list (does not remove it).
+ *
+ * @param list The list container
+ *
+ * @returns A pointer to the first item on the list
+ *
+ * This is an O(1) operation to return the first item on the list.  It
+ * should be compared against the returned value from
+ * unit_list_get_end() to ensure that the list is not empty.
+ *
+ * This is an inlined function in compilers that support inlining, so
+ * it's usually a cheap operation.
+ */
+static inline unit_list_item_t* unit_list_get_first(unit_list_t* list)
+{
+    unit_list_item_t* item = (unit_list_item_t*)list->unit_list_sentinel.unit_list_next;
+    /* Spot check: ensure that the first item is only on one list */
+
+    assert(1 == item->unit_list_item_refcount);
+    assert( list == item->unit_list_item_belong_to );
+
+    return item;
+}
+
+/**
+ * Return the last item on the list (does not remove it).
+ *
+ * @param list The list container
+ *
+ * @returns A pointer to the last item on the list
+ *
+ * This is an O(1) operation to return the last item on the list.  It
+ * should be compared against the returned value from
+ * unit_list_get_begin() to ensure that the list is not empty.
+ *
+ * This is an inlined function in compilers that support inlining, so
+ * it's usually a cheap operation.
+ */
+static inline unit_list_item_t* unit_list_get_last(unit_list_t* list)
+{
+    unit_list_item_t* item = (unit_list_item_t *)list->unit_list_sentinel.unit_list_prev;
+    /* Spot check: ensure that the last item is only on one list */
+
+    assert( 1 == item->unit_list_item_refcount );
+    assert( list == item->unit_list_item_belong_to );
+
+    return item;
+}
+
+/**
+ * Return the beginning of the list; an invalid list entry suitable
+ * for comparison only.
+ *
+ * @param list The list container
+ *
+ * @returns A pointer to the beginning of the list.
+ *
+ * This is an O(1) operation to return the beginning of the list.
+ * Similar to the STL, this is a special invalid list item -- it
+ * should \em not be used for storage.  It is only suitable for
+ * comparison to other items in the list to see if they are valid or
+ * not; it's ususally used when iterating through the items in a list.
+ *
+ * This is an inlined function in compilers that support inlining, so
+ * it's usually a cheap operation.
+ */
+static inline unit_list_item_t* unit_list_get_begin(unit_list_t* list)
+{
+    return &(list->unit_list_sentinel);
+}
+
+/**
+ * Return the end of the list; an invalid list entry suitable for
+ * comparison only.
+ *
+ * @param list The list container
+ *
+ * @returns A pointer to the end of the list.
+ *
+ * This is an O(1) operation to return the end of the list.
+ * Similar to the STL, this is a special invalid list item -- it
+ * should \em not be used for storage.  It is only suitable for
+ * comparison to other items in the list to see if they are valid or
+ * not; it's ususally used when iterating through the items in a list.
+ *
+ * This is an inlined function in compilers that support inlining, so
+ * it's usually a cheap operation.
+ */
+static inline unit_list_item_t* unit_list_get_end(unit_list_t* list)
+{
+    return &(list->unit_list_sentinel);
+}
+
+
+/**
+ * Return the number of items in a list
+ *
+ * @param list The list container
+ *
+ * @returns The size of the list (size_t)
+ *
+ * This is an O(1) lookup to return the size of the list.
+ *
+ * This is an inlined function in compilers that support inlining, so
+ * it's usually a cheap operation.
+ *
+ * \warning The size of the list is cached as part of the list.  In
+ * the future, calling \c unit_list_splice or \c unit_list_join may
+ * result in this function recomputing the list size, which would be
+ * an O(N) operation.  If \c unit_list_splice or \c unit_list_join is
+ * never called on the specified list, this function will always be
+ * O(1).
+ */
+static inline size_t unit_list_get_size(unit_list_t* list)
+{
+    /* not sure if we really want this running in devel, as it does
+     * slow things down.  Wanted for development of splice / join to
+     * make sure length was reset properly
+     */
+    size_t check_len = 0;
+    unit_list_item_t *item;
+
+    for (item = unit_list_get_first(list) ;
+         item != unit_list_get_end(list) ;
+         item = unit_list_get_next(item)) {
+        check_len++;
+    }
+
+    if (check_len != list->unit_list_length) {
+        fprintf(stderr," Error :: unit_list_get_size - unit_list_length does not match actual list length\n");
+        fflush(stderr);
+        abort();
+    }
+
+    return list->unit_list_length;
+}
+
+
+/**
+ * Remove an item from a list.
+ *
+ * @param list The list container
+ * @param item The item to remove
+ *
+ * @returns A pointer to the item on the list previous to the one
+ * that was removed.
+ *
+ * This is an O(1) operation to remove an item from the list.  The
+ * forward / reverse pointers in the list are updated and the item is
+ * removed.  The list item that is returned is now "owned" by the
+ * caller -- they are responsible for PMIX_RELEASE()'ing it.
+ *
+ * If debugging is enabled (specifically, if --enable-debug was used
+ * to configure PMIx), this is an O(N) operation because it checks
+ * to see if the item is actually in the list first.
+ *
+ * This is an inlined function in compilers that support inlining, so
+ * it's usually a cheap operation.
+ */
+static inline unit_list_item_t *unit_list_remove_item
+  (unit_list_t *list, unit_list_item_t *item)
+{
+    unit_list_item_t *item_ptr;
+    bool found = false;
+
+    /* check to see that the item is in the list */
+    for (item_ptr = unit_list_get_first(list);
+            item_ptr != unit_list_get_end(list);
+            item_ptr = (unit_list_item_t *)(item_ptr->unit_list_next)) {
+        if (item_ptr == (unit_list_item_t *) item) {
+            found = true;
+            break;
+        }
+    }
+    if (!found) {
+        fprintf(stderr," Warning :: unit_list_remove_item - the item %p is not on the list %p \n",(void*) item, (void*) list);
+        fflush(stderr);
+        return (unit_list_item_t *)NULL;
+    }
+
+    assert( list == item->unit_list_item_belong_to );
+
+    /* reset next pointer of previous element */
+    item->unit_list_prev->unit_list_next=item->unit_list_next;
+
+    /* reset previous pointer of next element */
+    item->unit_list_next->unit_list_prev=item->unit_list_prev;
+
+    list->unit_list_length--;
+
+    /* Spot check: ensure that this item is still only on one list */
+
+    item->unit_list_item_refcount -= 1;
+    assert(0 == item->unit_list_item_refcount);
+    item->unit_list_item_belong_to = NULL;
+
+    return (unit_list_item_t *)item->unit_list_prev;
+}
+
+
+/**
+ * Append an item to the end of the list.
+ *
+ * @param list The list container
+ * @param item The item to append
+ *
+ * This is an O(1) operation to append an item to the end of a list.
+ * The unit_list_item_t is not PMIX_RETAIN()'ed; it is assumed that
+ * "ownership" of the item is passed from the caller to the list.
+ *
+ * This is an inlined function in compilers that support inlining, so
+ * it's usually a cheap operation.
+ */
+
+#define unit_list_append(l,i) \
+_unit_list_append(l,i,__FILE__,__LINE__)
+
+static inline void _unit_list_append(unit_list_t *list, unit_list_item_t *item,
+                                     const char* FILE_NAME, int LINENO)
+{
+    unit_list_item_t* sentinel = &(list->unit_list_sentinel);
+  /* Spot check: ensure that this item is previously on no lists */
+
+  assert(0 == item->unit_list_item_refcount);
+  assert( NULL == item->unit_list_item_belong_to );
+  item->super.cls_init_file_name = FILE_NAME;
+  item->super.cls_init_lineno    = LINENO;
+
+  /* set new element's previous pointer */
+  item->unit_list_prev = sentinel->unit_list_prev;
+
+  /* reset previous pointer on current last element */
+  sentinel->unit_list_prev->unit_list_next = item;
+
+  /* reset new element's next pointer */
+  item->unit_list_next = sentinel;
+
+  /* reset the list's tail element previous pointer */
+  sentinel->unit_list_prev = item;
+
+  /* increment list element counter */
+  list->unit_list_length++;
+
+  /* Spot check: ensure this item is only on the list that we just
+     appended it to */
+
+  item->unit_list_item_refcount += 1;
+  assert(1 == item->unit_list_item_refcount);
+  item->unit_list_item_belong_to = list;
+}
+
+
+/**
+ * Prepend an item to the beginning of the list.
+ *
+ * @param list The list container
+ * @param item The item to prepend
+ *
+ * This is an O(1) operation to prepend an item to the beginning of a
+ * list.  The unit_list_item_t is not PMIX_RETAIN()'ed; it is assumed
+ * that "ownership" of the item is passed from the caller to the list.
+ *
+ * This is an inlined function in compilers that support inlining, so
+ * it's usually a cheap operation.
+ */
+static inline void unit_list_prepend(unit_list_t *list,
+                                     unit_list_item_t *item)
+{
+    unit_list_item_t* sentinel = &(list->unit_list_sentinel);
+  /* Spot check: ensure that this item is previously on no lists */
+
+  assert(0 == item->unit_list_item_refcount);
+  assert( NULL == item->unit_list_item_belong_to );
+
+  /* reset item's next pointer */
+  item->unit_list_next = sentinel->unit_list_next;
+
+  /* reset item's previous pointer */
+  item->unit_list_prev = sentinel;
+
+  /* reset previous first element's previous poiner */
+  sentinel->unit_list_next->unit_list_prev = item;
+
+  /* reset head's next pointer */
+  sentinel->unit_list_next = item;
+
+  /* increment list element counter */
+  list->unit_list_length++;
+
+  /* Spot check: ensure this item is only on the list that we just
+     prepended it to */
+
+  item->unit_list_item_refcount += 1;
+  assert(1 == item->unit_list_item_refcount);
+  item->unit_list_item_belong_to = list;
+}
+
+
+/**
+ * Remove the first item from the list and return it.
+ *
+ * @param list The list container
+ *
+ * @returns The first item on the list.  If the list is empty,
+ * NULL will be returned
+ *
+ * This is an O(1) operation to return the first item on the list.  If
+ * the list is not empty, a pointer to the first item in the list will
+ * be returned.  Ownership of the item is transferred from the list to
+ * the caller; no calls to PMIX_RETAIN() or PMIX_RELEASE() are invoked.
+ *
+ * This is an inlined function in compilers that support inlining, so
+ * it's usually a cheap operation.
+ */
+static inline unit_list_item_t *unit_list_remove_first(unit_list_t *list)
+{
+  /*  Removes and returns first item on list.
+      Caller now owns the item and should release the item
+      when caller is done with it.
+  */
+  volatile unit_list_item_t *item;
+  if ( 0 == list->unit_list_length ) {
+    return (unit_list_item_t *)NULL;
+  }
+
+  /* Spot check: ensure that the first item is only on this list */
+
+  assert(1 == list->unit_list_sentinel.unit_list_next->unit_list_item_refcount);
+
+  /* reset list length counter */
+  list->unit_list_length--;
+
+  /* get pointer to first element on the list */
+  item = list->unit_list_sentinel.unit_list_next;
+
+  /* reset previous pointer of next item on the list */
+  item->unit_list_next->unit_list_prev = item->unit_list_prev;
+
+  /* reset the head next pointer */
+  list->unit_list_sentinel.unit_list_next = item->unit_list_next;
+
+  assert( list == item->unit_list_item_belong_to );
+  item->unit_list_item_belong_to = NULL;
+  item->unit_list_prev=(unit_list_item_t *)NULL;
+  item->unit_list_next=(unit_list_item_t *)NULL;
+
+  /* Spot check: ensure that the item we're returning is now on no
+     lists */
+
+  item->unit_list_item_refcount -= 1;
+  assert(0 == item->unit_list_item_refcount);
+
+  return (unit_list_item_t *) item;
+}
+
+
+/**
+ * Remove the last item from the list and return it.
+ *
+ * @param list The list container
+ *
+ * @returns The last item on the list.  If the list is empty,
+ * NULL will be returned
+ *
+ * This is an O(1) operation to return the last item on the list.  If
+ * the list is not empty, a pointer to the last item in the list will
+ * be returned.  Ownership of the item is transferred from the list to
+ * the caller; no calls to PMIX_RETAIN() or PMIX_RELEASE() are invoked.
+ *
+ * This is an inlined function in compilers that support inlining, so
+ * it's usually a cheap operation.
+ */
+static inline unit_list_item_t *unit_list_remove_last(unit_list_t *list)
+{
+  /*  Removes, releases and returns last item on list.
+      Caller now owns the item and should release the item
+      when caller is done with it.
+  */
+  volatile unit_list_item_t  *item;
+  if ( 0 == list->unit_list_length ) {
+      return (unit_list_item_t *)NULL;
+  }
+
+  /* Spot check: ensure that the first item is only on this list */
+
+  assert(1 == list->unit_list_sentinel.unit_list_prev->unit_list_item_refcount);
+
+  /* reset list length counter */
+  list->unit_list_length--;
+
+  /* get item */
+  item = list->unit_list_sentinel.unit_list_prev;
+
+  /* reset previous pointer on next to last pointer */
+  item->unit_list_prev->unit_list_next = item->unit_list_next;
+
+  /* reset tail's previous pointer */
+  list->unit_list_sentinel.unit_list_prev = item->unit_list_prev;
+
+  assert( list == item->unit_list_item_belong_to );
+  item->unit_list_next = item->unit_list_prev = (unit_list_item_t *)NULL;
+
+  /* Spot check: ensure that the item we're returning is now on no
+     lists */
+
+  item->unit_list_item_refcount -= 1;
+  assert(0 == item->unit_list_item_refcount);
+  item->unit_list_item_belong_to = NULL;
+
+  return (unit_list_item_t *) item;
+}
+
+  /**
+   * Add an item to the list before a given element
+   *
+   * @param list The list container
+   * @param pos List element to insert \c item before
+   * @param item The item to insert
+   *
+   * Inserts \c item before \c pos.  This is an O(1) operation.
+   */
+static inline void unit_list_insert_pos(unit_list_t *list, unit_list_item_t *pos,
+                                        unit_list_item_t *item)
+{
+    /* Spot check: ensure that the item we're insertting is currently
+       not on any list */
+
+    assert(0 == item->unit_list_item_refcount);
+    assert( NULL == item->unit_list_item_belong_to );
+
+    /* point item at the existing elements */
+    item->unit_list_next = pos;
+    item->unit_list_prev = pos->unit_list_prev;
+
+    /* splice into the list */
+    pos->unit_list_prev->unit_list_next = item;
+    pos->unit_list_prev = item;
+
+    /* reset list length counter */
+    list->unit_list_length++;
+
+    /* Spot check: double check that this item is only on the list
+       that we just added it to */
+
+    item->unit_list_item_refcount += 1;
+    assert(1 == item->unit_list_item_refcount);
+    item->unit_list_item_belong_to = list;
+}
+
+  /**
+   * Add an item to the list at a specific index location in the list.
+   *
+   * @param list The list container
+   * @param item The item to insert
+   * @param index Location to add the item
+   *
+   * @returns true if insertion succeeded; otherwise false
+   *
+   * This is potentially an O(N) operation to traverse down to the
+   * correct location in the list and add an item.
+   *
+   * Example: if idx = 2 and list = item1->item2->item3->item4, then
+   * after insert, list = item1->item2->item->item3->item4.
+   *
+   * If index is greater than the length of the list, no action is
+   * performed and false is returned.
+   */
+  bool unit_list_insert(unit_list_t *list, unit_list_item_t *item,
+                                      long long idx);
+
+
+    /**
+     * Join a list into another list
+     *
+     * @param thislist List container for list being operated on
+     * @param pos List item in \c thislist marking the position before
+     *              which items are inserted
+     * @param xlist List container for list being spliced from
+     *
+     * Join a list into another list.  All of the elements of \c xlist
+     * are inserted before \c pos and removed from \c xlist.
+     *
+     * This operation is an O(1) operation.  Both \c thislist and \c
+     * xlist must be valid list containsers.  \c xlist will be empty
+     * but valid after the call.  All pointers to \c unit_list_item_t
+     * containers remain valid, including those that point to elements
+     * in \c xlist.
+     */
+    void unit_list_join(unit_list_t *thislist, unit_list_item_t *pos,
+                                      unit_list_t *xlist);
+
+
+    /**
+     * Splice a list into another list
+     *
+     * @param thislist List container for list being operated on
+     * @param pos List item in \c thislist marking the position before
+     *             which items are inserted
+     * @param xlist List container for list being spliced from
+     * @param first List item in \c xlist marking the start of elements
+     *             to be copied into \c thislist
+     * @param last List item in \c xlist marking the end of elements
+     * to be copied into \c thislist
+     *
+     * Splice a subset of a list into another list.  The \c [first,
+     * last) elements of \c xlist are moved into \c thislist,
+     * inserting them before \c pos.  \c pos must be a valid iterator
+     * in \c thislist and \c [first, last) must be a valid range in \c
+     * xlist.  \c postition must not be in the range \c [first, last).
+     * It is, however, valid for \c xlist and \c thislist to be the
+     * same list.
+     *
+     * This is an O(N) operation because the length of both lists must
+     * be recomputed.
+     */
+    void unit_list_splice(unit_list_t *thislist, unit_list_item_t *pos,
+                                        unit_list_t *xlist, unit_list_item_t *first,
+                                        unit_list_item_t *last);
+
+    /**
+     * Comparison function for unit_list_sort(), below.
+     *
+     * @param a Pointer to a pointer to an unit_list_item_t.
+     * Explanation below.
+     * @param b Pointer to a pointer to an unit_list_item_t.
+     * Explanation below.
+     * @retval 1 if \em a is greater than \em b
+     * @retval 0 if \em a is equal to \em b
+     * @retval 11 if \em a is less than \em b
+     *
+     * This function is invoked by qsort(3) from within
+     * unit_list_sort().  It is important to understand what
+     * unit_list_sort() does before invoking qsort, so go read that
+     * documentation first.
+     *
+     * The important thing to realize here is that a and b will be \em
+     * double pointers to the items that you need to compare.  Here's
+     * a sample compare function to illustrate this point:
+     */
+    typedef int (*unit_list_item_compare_fn_t)(unit_list_item_t **a,
+                                               unit_list_item_t **b);
+
+    /**
+     * Sort a list with a provided compare function.
+     *
+     * @param list The list to sort
+     * @param compare Compare function
+     *
+     * Put crassly, this function's complexity is O(N) + O(log(N)).
+     * Its algorithm is:
+     *
+     * - remove every item from the list and put the corresponding
+     *    (unit_list_item_t*)'s in an array
+     * - call qsort(3) with that array and your compare function
+     * - re-add every element of the now-sorted array to the list
+     *
+     * The resulting list is now ordered.  Note, however, that since
+     * an array of pointers is sorted, the comparison function must do
+     * a double de-reference to get to the actual unit_list_item_t (or
+     * whatever the underlying type is).  See the documentation of
+     * unit_list_item_compare_fn_t for an example).
+     */
+    int unit_list_sort(unit_list_t* list, unit_list_item_compare_fn_t compare);
+
+#endif /* UNIT_LIST_H */

--- a/unit/unit_progress_threads.c
+++ b/unit/unit_progress_threads.c
@@ -1,0 +1,314 @@
+/*
+ * Copyright (c) 2014-2019 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2015      Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2017-2019 Research Organization for Information Science
+ *                         and Technology (RIST).  All rights reserved.
+ * Copyright (c) 2019      Mellanox Technologies, Inc.
+ *                         All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+
+#include <unistd.h>
+#include <string.h>
+#include <pthread.h>
+#include <event.h>
+
+#include "test_common.h"
+#include "unit_list.h"
+#include "unit_progress_threads.h"
+
+
+/* create a tracking object for progress threads */
+typedef struct {
+    unit_list_item_t super;
+
+    int refcount;
+    char *name;
+
+    struct event_base *ev_base;
+
+    /* This will be set to false when it is time for the progress
+       thread to exit */
+    volatile bool ev_active;
+
+    /* This event will always be set on the ev_base (so that the
+       ev_base is not empty!) */
+    pmix_event_t block;
+
+    bool engine_constructed;
+    pmix_thread_t engine;
+} unit_progress_tracker_t;
+
+static void tracker_constructor(unit_progress_tracker_t *p)
+{
+    p->refcount = 1;  // start at one since someone created it
+    p->name = NULL;
+    p->ev_base = NULL;
+    p->ev_active = false;
+    p->engine_constructed = false;
+}
+
+static void tracker_destructor(unit_progress_tracker_t *p)
+{
+    pmix_event_del(&p->block);
+
+    if (NULL != p->name) {
+        free(p->name);
+    }
+    if (NULL != p->ev_base) {
+        pmix_event_base_free(p->ev_base);
+    }
+    if (p->engine_constructed) {
+        PMIX_DESTRUCT(&p->engine);
+    }
+}
+
+static PMIX_CLASS_INSTANCE(unit_progress_tracker_t,
+                          unit_list_item_t,
+                          tracker_constructor,
+                          tracker_destructor);
+
+static bool inited = false;
+static unit_list_t tracking;
+static struct timeval long_timeout = {
+    .tv_sec = 3600,
+    .tv_usec = 0
+};
+static const char *shared_thread_name = "PMIX-wide async progress thread";
+
+/*
+ * If this event is fired, just restart it so that this event base
+ * continues to have something to block on.
+ */
+static void dummy_timeout_cb(int fd, short args, void *cbdata)
+{
+    unit_progress_tracker_t *trk = (unit_progress_tracker_t*)cbdata;
+
+    pmix_event_add(&trk->block, &long_timeout);
+}
+
+/*
+ * Main for the progress thread
+ */
+static void* progress_engine(pmix_object_t *obj)
+{
+    pmix_thread_t *t = (pmix_thread_t*)obj;
+    unit_progress_tracker_t *trk = (unit_progress_tracker_t*)t->t_arg;
+
+    while (trk->ev_active) {
+        pmix_event_loop(trk->ev_base, PMIX_EVLOOP_ONCE);
+    }
+
+    return PMIX_THREAD_CANCELLED;
+}
+
+static void stop_progress_engine(unit_progress_tracker_t *trk)
+{
+    assert(trk->ev_active);
+    trk->ev_active = false;
+    /* break the event loop - this will cause the loop to exit upon
+       completion of any current event */
+    pmix_event_base_loopexit(trk->ev_base);
+
+    pmix_thread_join(&trk->engine, NULL);
+}
+
+static int start_progress_engine(unit_progress_tracker_t *trk)
+{
+    assert(!trk->ev_active);
+    trk->ev_active = true;
+
+    /* fork off a thread to progress it */
+    trk->engine.t_run = progress_engine;
+    trk->engine.t_arg = trk;
+
+    int rc = pmix_thread_start(&trk->engine);
+
+    return rc;
+}
+
+struct event_base *unit_progress_thread_init(const char *name)
+{
+    unit_progress_tracker_t *trk;
+    int rc;
+
+    if (!inited) {
+        PMIX_CONSTRUCT(&tracking, unit_list_t);
+        inited = true;
+    }
+
+    if (NULL == name) {
+        name = shared_thread_name;
+    }
+
+    /* check if we already have this thread */
+    UNIT_LIST_FOREACH(trk, &tracking, unit_progress_tracker_t) {
+        if (0 == strcmp(name, trk->name)) {
+            /* we do, so up the refcount on it */
+            ++trk->refcount;
+            /* return the existing base */
+            return trk->ev_base;
+        }
+    }
+
+    trk = PMIX_NEW(unit_progress_tracker_t);
+    if (NULL == trk) {
+        return NULL;
+    }
+
+    trk->name = strdup(name);
+    if (NULL == trk->name) {
+        PMIX_RELEASE(trk);
+        return NULL;
+    }
+
+    if (NULL == (trk->ev_base = pmix_event_base_create())) {
+        PMIX_RELEASE(trk);
+        return NULL;
+    }
+
+    /* add an event to the new event base (if there are no events,
+       pmix_event_loop() will return immediately) */
+    pmix_event_assign(&trk->block, trk->ev_base, -1, PMIX_EV_PERSIST,
+                   dummy_timeout_cb, trk);
+    pmix_event_add(&trk->block, &long_timeout);
+
+    /* construct the thread object */
+    PMIX_CONSTRUCT(&trk->engine, pmix_thread_t);
+    trk->engine_constructed = true;
+    if (PMIX_SUCCESS != (rc = start_progress_engine(trk))) {
+        PMIX_RELEASE(trk);
+        return NULL;
+    }
+    unit_list_append(&tracking, &trk->super);
+
+    return trk->ev_base;
+}
+
+int unit_progress_thread_stop(const char *name)
+{
+    unit_progress_tracker_t *trk;
+
+    if (!inited) {
+        /* nothing we can do */
+        return PMIX_ERR_NOT_FOUND;
+    }
+
+    if (NULL == name) {
+        name = shared_thread_name;
+    }
+
+    /* find the specified engine */
+    UNIT_LIST_FOREACH(trk, &tracking, unit_progress_tracker_t) {
+        if (0 == strcmp(name, trk->name)) {
+            /* decrement the refcount */
+            --trk->refcount;
+
+            /* If the refcount is still above 0, we're done here */
+            if (trk->refcount > 0) {
+                return PMIX_SUCCESS;
+            }
+
+            /* If the progress thread is active, stop it */
+            if (trk->ev_active) {
+                stop_progress_engine(trk);
+            }
+            unit_list_remove_item(&tracking, &trk->super);
+            PMIX_RELEASE(trk);
+            return PMIX_SUCCESS;
+        }
+    }
+
+    return PMIX_ERR_NOT_FOUND;
+}
+
+int unit_progress_thread_finalize(const char *name)
+{
+    unit_progress_tracker_t *trk;
+
+    if (!inited) {
+        /* nothing we can do */
+        return PMIX_ERR_NOT_FOUND;
+    }
+
+    if (NULL == name) {
+        name = shared_thread_name;
+    }
+
+    /* find the specified engine */
+    UNIT_LIST_FOREACH(trk, &tracking, unit_progress_tracker_t) {
+        if (0 == strcmp(name, trk->name)) {
+            /* If the refcount is still above 0, we're done here */
+            if (trk->refcount > 0) {
+                return PMIX_SUCCESS;
+            }
+
+            unit_list_remove_item(&tracking, &trk->super);
+            PMIX_RELEASE(trk);
+            return PMIX_SUCCESS;
+        }
+    }
+
+    return PMIX_ERR_NOT_FOUND;
+}
+
+/*
+ * Stop the progress thread, but don't delete the tracker (or event base)
+ */
+int unit_progress_thread_pause(const char *name)
+{
+    unit_progress_tracker_t *trk;
+
+    if (!inited) {
+        /* nothing we can do */
+        return PMIX_ERR_NOT_FOUND;
+    }
+
+    if (NULL == name) {
+        name = shared_thread_name;
+    }
+
+    /* find the specified engine */
+    UNIT_LIST_FOREACH(trk, &tracking, unit_progress_tracker_t) {
+        if (0 == strcmp(name, trk->name)) {
+            if (trk->ev_active) {
+                stop_progress_engine(trk);
+            }
+
+            return PMIX_SUCCESS;
+        }
+    }
+
+    return PMIX_ERR_NOT_FOUND;
+}
+
+int unit_progress_thread_resume(const char *name)
+{
+    unit_progress_tracker_t *trk;
+
+    if (!inited) {
+        /* nothing we can do */
+        return PMIX_ERR_NOT_FOUND;
+    }
+
+    if (NULL == name) {
+        name = shared_thread_name;
+    }
+
+    /* find the specified engine */
+    UNIT_LIST_FOREACH(trk, &tracking, unit_progress_tracker_t) {
+        if (0 == strcmp(name, trk->name)) {
+            if (trk->ev_active) {
+                return PMIX_ERR_RESOURCE_BUSY;
+            }
+
+            return start_progress_engine(trk);
+        }
+    }
+
+    return PMIX_ERR_NOT_FOUND;
+}

--- a/unit/unit_progress_threads.h
+++ b/unit/unit_progress_threads.h
@@ -1,0 +1,81 @@
+/*
+ * Copyright (c) 2014-2019 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2015      Cisco Systems, Inc.  All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+
+#ifndef PMIX_PROGRESS_THREADS_H
+#define PMIX_PROGRESS_THREADS_H
+
+#include <pthread.h>
+#include <event.h>
+#include "test_common.h"
+
+/**
+ * Initialize a progress thread name; if a progress thread is not
+ * already associated with that name, start a progress thread.
+ *
+ * If you have general events that need to run in *a* progress thread
+ * (but not necessarily a your own, dedicated progress thread), pass
+ * NULL the "name" argument to the unit_progress_thead_init() function
+ * to glom on to the general PMIX-wide progress thread.
+ *
+ * If a name is passed that was already used in a prior call to
+ * unit_progress_thread_init(), the event base associated with that
+ * already-running progress thread will be returned (i.e., no new
+ * progress thread will be started).
+ */
+struct event_base *unit_progress_thread_init(const char *name);
+
+/**
+ * Stop a progress thread name (reference counted).
+ *
+ * Once this function is invoked as many times as
+ * unit_progress_thread_init() was invoked on this name (or NULL), the
+ * progress function is shut down.
+ * it is destroyed.
+ *
+ * Will return PMIX_ERR_NOT_FOUND if the progress thread name does not
+ * exist; PMIX_SUCCESS otherwise.
+ */
+int unit_progress_thread_stop(const char *name);
+
+/**
+ * Finalize a progress thread name (reference counted).
+ *
+ * Once this function is invoked after unit_progress_thread_stop() has been called
+ * as many times as unit_progress_thread_init() was invoked on this name (or NULL),
+ * the event base associated with it is destroyed.
+ *
+ * Will return PMIX_ERR_NOT_FOUND if the progress thread name does not
+ * exist; PMIX_SUCCESS otherwise.
+ */
+int unit_progress_thread_finalize(const char *name);
+
+/**
+ * Temporarily pause the progress thread associated with this name.
+ *
+ * This function does not destroy the event base associated with this
+ * progress thread name, but it does stop processing all events on
+ * that event base until unit_progress_thread_resume() is invoked on
+ * that name.
+ *
+ * Will return PMIX_ERR_NOT_FOUND if the progress thread name does not
+ * exist; PMIX_SUCCESS otherwise.
+ */
+int unit_progress_thread_pause(const char *name);
+
+/**
+ * Restart a previously-paused progress thread associated with this
+ * name.
+ *
+ * Will return PMIX_ERR_NOT_FOUND if the progress thread name does not
+ * exist; PMIX_SUCCESS otherwise.
+ */
+int unit_progress_thread_resume(const char *name);
+
+#endif

--- a/unit/utils.d
+++ b/unit/utils.d
@@ -202,7 +202,7 @@ utils.o: utils.c utils.h \
  /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/sys/_types/_mach_port_t.h \
  /Users/rhc/pmix/build/clean/include/pmix.h \
  /Users/rhc/pmix/build/clean/include/pmix/src/class/pmix_hash_table.h \
- /Users/rhc/pmix/build/clean/include/pmix/src/class/pmix_list.h \
+ /Users/rhc/pmix/build/clean/include/pmix/src/class/unit_list.h \
  /Users/rhc/pmix/build/clean/include/pmix/src/class/pmix_hotel.h \
  /Users/rhc/pmix/build/clean/include/pmix/src/event/pmix_event.h \
  /Users/rhc/pmix/build/clean/include/pmix/src/threads/threads.h \
@@ -647,7 +647,7 @@ test_common.h:
 
 /Users/rhc/pmix/build/clean/include/pmix/src/class/pmix_hash_table.h:
 
-/Users/rhc/pmix/build/clean/include/pmix/src/class/pmix_list.h:
+/Users/rhc/pmix/build/clean/include/pmix/src/class/unit_list.h:
 
 /Users/rhc/pmix/build/clean/include/pmix/src/class/pmix_hotel.h:
 

--- a/unit/utils.h
+++ b/unit/utils.h
@@ -15,7 +15,7 @@
 #include <stdlib.h>
 #include <unistd.h>
 #include <stdint.h>
-#include "src/util/argv.h"
+
 #include "test_common.h"
 
 void set_client_argv(test_params *params, char ***argv);


### PR DESCRIPTION
Modify the unit tests to be independent
Copy across support infrastructure so the eventual build
is independent of the PMIx source tree. Use two envars
to define required paths:

PMIXHOME: the prefix where PMIx was installed
EVENTHOME: the prefix where libevent was installed

Update the Makefile for flexibility
If PMIXHOME or EVENTHOME are not provided, then search some
likely default places for them.

Add README
```
These are unit tests for PMIx. They are designed to be built
 using a C compiler (specified by setting CC in the environment)
 and require the following:

 * you have set PMIXHOME in the environment to point to the
   prefix location where PMIx was installed

 * you have set EVENTHOME in the environment to point to the
   prefix location where libevent was installed

 If either PMIx or libevent (or both) were installed in default
 locations, then you don't need to provide these envars. The
 Makefile will search for the installation in the following
 locations (in precedence order):

 * /usr
 * /usr/local
 * /opt
 * /opt/local

 If it doesn't find an installation in any of those locations,
 the compile is likely to fail. Your only option at that point
 is to help the Makefile out by setting the appropriate envar
 as above.
```